### PR TITLE
M5Stampをインターネットに接続し，現在時刻を取得する機能の実装 #3

### DIFF
--- a/MainCode/MainCode.ino
+++ b/MainCode/MainCode.ino
@@ -1,9 +1,35 @@
-void setup() {
-  // put your setup code here, to run once:
+#include <WiFi.h>
 
+const char* ssid = "myssid";
+const char* password = "mypassword";
+struct tm timeInfo;
+char timeData[20];
+
+void setup() {
+  Serial.begin(115200);
+  connectToAccessPoint(ssid, password);
+  configTime(9 * 3600L, 0, "ntp.nict.jp", "time.google.com");
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
+  getLocalTime(&timeInfo);
+  sprintf(timeData, "%04d/%02d/%02d %02d:%02d:%02d", timeInfo.tm_year + 1900, timeInfo.tm_mon + 1, timeInfo.tm_mday, timeInfo.tm_hour, timeInfo.tm_min, timeInfo.tm_sec);
+  Serial.println(timeData);
+  delay(1000);
+}
 
+void connectToAccessPoint(const char* ssid, const char* password){
+  WiFi.begin(ssid, password);
+  int waitCountInSec = 0;
+  while(WiFi.status() != WL_CONNECTED){
+    waitCountInSec++;
+    delay(1000);
+    Serial.print(".");
+    if(waitCountInSec == 10){
+      Serial.println("\nWi-Fi Connection failed. Please check the ssid and password.");
+      delay(3000);
+      ESP.restart();
+    }
+  }
+  Serial.println("\nWiFi connected.");
 }


### PR DESCRIPTION
## 実装内容

- アクセスポイントに接続するため，`connectToAccessPoint` メソッドを定義。
- シリアルモニタに時刻を毎秒表示する機能の実装。

## 確認手順

- M5Stampにプログラムを書き込む。
- シリアルモニタを開き，下記の画像のような表示があることを確認。

## スクリーンショット

- M5Stampを起動後のシリアルモニタ
<img width="216" alt="スクリーンショット 2022-06-19 19 39 31" src="https://user-images.githubusercontent.com/51685340/176893550-bc502050-8ccc-4b5e-97e5-b607d7a4bfbb.png">

## 確認した環境

- M1 MacBook Pro
- macOS Monterey version 12.4

resolve #3 