### PR TITLE
.gitignoreファイルの作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk


### PR DESCRIPTION
## 実装内容

- .gitignoreファイルの作成。

## 確認手順

- `stamp-iot/` に **.gitignore** ファイルが作成されていることを確認する。

## スクリーンショット

- `stamp-iot/` に移動し，`$ ls -a` を実行した結果
  <img width="520" alt="スクリーンショット 2022-07-01 22 16 05" src="https://user-images.githubusercontent.com/51685340/176902110-da74ca8f-0f9b-42e1-b476-953fb057e513.png">

## 確認した環境

- M1 MacBook Pro
- macOS Monterey version 12.4

resolve #6 