### PR TITLE
測定結果確認画面のuriをidからuuidに変更する

### DIFF
--- a/.github/workflows/github-action.backend.yml
+++ b/.github/workflows/github-action.backend.yml
@@ -52,7 +52,11 @@ jobs:
       - name: Copy artifacts
         run: cp -rp /home/ems/tmp/backend/${{ github.ref_name }}/* /home/ems/deploy/backend/${{ github.ref_name }}
       - name: Link artifacts to server
-        run: ln -fns /home/ems/deploy/backend/feature/67/artifact/server.jar /home/ems/deploy/backend
+        run: ln -fns /home/ems/deploy/backend/${{ github.ref_name }}/artifact/server.jar /home/ems/deploy/backend/server.jar
+      - name: Kill existing Java task
+        run: sudo systemctl stop java
+      - name: Run boot script
+        run: sudo systemctl start java
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/backend/src/main/java/com/example/stamp_app/controller/MeasuredDataController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/MeasuredDataController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.UUID;
 
 @Controller
 @RequestMapping(value = "/ems/measured-data")
@@ -46,13 +47,13 @@ public class MeasuredDataController {
     /**
      * アカウントIDとマイコンIDを指定して測定結果を取得するAPI
      *
-     * @param microControllerId マイコンID
+     * @param microControllerUuid マイコンID
      * @return 測定結果
      */
     @GetMapping
-    public ResponseEntity<MeasuredDataGetResponse> getMeasuredData(@RequestParam BigInteger microControllerId, HttpServletRequest httpServletRequest) {
+    public ResponseEntity<MeasuredDataGetResponse> getMeasuredData(@RequestParam String microControllerUuid, HttpServletRequest httpServletRequest) {
         System.out.println(">> Measured Data Controller(POST)");
-        System.out.println("RequestParam: microControllerId:" + microControllerId);
+        System.out.println("RequestParam: microControllerUuid:" + microControllerUuid);
 
         var cookieLIst = httpServletRequest.getCookies();
 
@@ -60,7 +61,7 @@ public class MeasuredDataController {
 
         var userUuid = redisService.getUserUuidFromSessionUuid(sessionUuid);
 
-        var response = measuredDataService.getMeasuredData(userUuid, microControllerId);
+        var response = measuredDataService.getMeasuredData(userUuid, microControllerUuid);
 
         System.out.println("<< Measured Data Controller(POST)");
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/backend/src/main/java/com/example/stamp_app/controller/response/MicroControllerGetResponse.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/response/MicroControllerGetResponse.java
@@ -7,11 +7,14 @@ import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Data
 public class MicroControllerGetResponse {
 
     private BigInteger id;
+
+    private UUID uuid;
 
     private String name;
 
@@ -29,6 +32,7 @@ public class MicroControllerGetResponse {
         microControllerList.forEach((microController) -> {
             var microControllerGetResponse = new MicroControllerGetResponse();
             microControllerGetResponse.setId(microController.getId());
+            microControllerGetResponse.setUuid(microController.getUuid());
             microControllerGetResponse.setName(microController.getName());
             microControllerGetResponse.setInterval(microController.getInterval());
             microControllerGetResponse.setMacAddress(microController.getMacAddress());

--- a/backend/src/main/java/com/example/stamp_app/entity/MicroController.java
+++ b/backend/src/main/java/com/example/stamp_app/entity/MicroController.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.NotNull;
 import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 
 @Entity
@@ -19,6 +20,12 @@ public class MicroController {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private BigInteger id;
+
+    @NotNull
+    @Column
+    @Comment(value = "端末UUID")
+    @Pattern(regexp = "^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$")
+    private UUID uuid;
 
     @Column
     @Comment(value = "端末名")

--- a/backend/src/main/java/com/example/stamp_app/repository/MicroControllerRepository.java
+++ b/backend/src/main/java/com/example/stamp_app/repository/MicroControllerRepository.java
@@ -9,5 +9,5 @@ import java.util.UUID;
 public interface MicroControllerRepository extends JpaRepository<MicroController, UUID> {
     MicroController findByMacAddress(String macAddress);
 
-    MicroController findById(BigInteger id);
+    MicroController findByUuid(UUID uuid);
 }

--- a/backend/src/main/java/com/example/stamp_app/service/MeasuredDataService.java
+++ b/backend/src/main/java/com/example/stamp_app/service/MeasuredDataService.java
@@ -126,14 +126,14 @@ public class MeasuredDataService {
      * マイコンIDを指定して，対象の測定結果を取得
      *
      * @param userUuid　ユーザーID
-     * @param microControllerId マイコンID
+     * @param microControllerUuid マイコンUUID
      * @return 測定結果リスト
      */
-    public MeasuredDataGetResponse getMeasuredData(String userUuid, BigInteger microControllerId) {
+    public MeasuredDataGetResponse getMeasuredData(String userUuid, String microControllerUuid) {
         MicroController microController = null;
 
         try{
-            microController = microControllerRepository.findById(microControllerId);
+            microController = microControllerRepository.findByUuid(UUID.fromString(microControllerUuid));
         }catch(Exception e){
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
@@ -153,6 +153,8 @@ public class MeasuredDataService {
 
         // SDI-12の測定データ成形
         List<Sdi12DataGetResponse> sdi12DataGetResponseList = new ArrayList<>();
+
+        var microControllerId = microController.getId();
 
         // アカウントとマイコンIDに紐づくSDI-12アドレスのリストを取得する(マイコンに紐づくアカウントが変更された場合を考慮)
         var sdi12AddressList = sdi12DataRepository.findSdiAddressGroupBySdiAddress(UUID.fromString(userUuid), microControllerId);

--- a/document/環境構築資料/本番環境整備ログ.md
+++ b/document/環境構築資料/本番環境整備ログ.md
@@ -189,3 +189,42 @@
     - windows から WSL2 へのポート転送設定を追加(自宅サーバー構築手順ログ 参照)
     - docker-compose-prod.yaml の nginx の ports に 443 を追加
   - LAN 外からの https アクセスでページが表示されることを確認
+
+### jar のサービス化
+- CDで再起動まで行おうとした際に，jarのログに終わりがなく，ワークフローが終わらないため，デーモン化する必要がある
+- `vim /home/etc/deploy/backend/kill.sh`
+
+  ```
+  #!/bin/bash
+  kill -9 $(lsof -t -i:8082)
+  ```
+
+- `sudo vim /etc/systemd/system/java.service`
+
+  ```
+  [Unit]
+  Description = Java Service
+
+  [Service]
+  ExecStart=/home/ems/deploy/backend/boot.sh
+  ExecStop=/home/ems/deploy/backend/kill.sh
+  Restart=no
+  Type=simple
+
+  [Install]
+  WantedBy=multi-user.target
+  ```
+
+- `sudo vim /etc/wsl.conf`
+
+  ```
+  [boot]
+  systemd=true
+  ```
+
+- `sudo systemctl daemon-reload`
+- `sudo systemctl enable java.service`
+- `sudo systemctl start java.service`
+- `sudo systemctl stop java.service`
+- `sudo vim /etc/sudoers`
+  - systemctl を実行時は特定のユーザーに sudo のパスワードなしで実行可能に設定する

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -79,6 +79,7 @@ watch(router.currentRoute, () => {
 $header-height: 50px;
 .main-view {
   height: calc(100vh - $header-height);
+  height: calc(100svh - $header-height);
   width: 100vw;
   margin-top: $header-height;
   position: relative;
@@ -89,6 +90,7 @@ $header-height: 50px;
   align-items: center;
   width: 100%;
   height: 100vh;
+  height: 100svh;
   z-index: 9999;
   position: absolute;
   top: 0;

--- a/frontend/src/methods/measuredData.ts
+++ b/frontend/src/methods/measuredData.ts
@@ -203,10 +203,12 @@ export const convertEnvironmentalKeyWordToTitle = (dataType: string) => {
  * マイコンIDを指定して測定結果を取得するAPI
  * @return  測定データ or null
  */
-export const fetchMeasuredData = async (microControllerId: string): Promise<MeasuredDataState> => {
+export const fetchMeasuredData = async (
+  microControllerUuid: string
+): Promise<MeasuredDataState> => {
   try {
     const rawResponse = await axios.get('/api/ems/measured-data', {
-      params: { microControllerId: microControllerId },
+      params: { microControllerUuid: microControllerUuid },
     });
     const response: MeasuredDataState = rawResponse.data;
     return response;

--- a/frontend/src/methods/microController.ts
+++ b/frontend/src/methods/microController.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 
 export class MicroController {
   id: number;
+  uuid: string;
   name: string;
   macAddress: string;
   interval: number;
@@ -13,6 +14,7 @@ export class MicroController {
 
 export type MicroControllerInfoState = {
   id: number;
+  uuid: string;
   name: string | null;
   macAddress: string;
   interval: number;
@@ -33,8 +35,8 @@ export const microControllerGet = async (): Promise<Array<MicroController>> => {
     const rawResponse = await axios.get('/api/ems/micro-controller/info');
     const response: Array<MicroController> = rawResponse.data;
     return response;
-  } catch {
-    return null;
+  } catch (e) {
+    throw e;
   }
 };
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -23,8 +23,9 @@ const routes: Array<RouteRecordRaw> = [
     component: Home,
   },
   {
-    path: '/result/:microControllerId',
+    path: '/result/:microControllerUuid',
     name: 'result',
+    props: true,
     component: MeasuredData,
   },
 ];

--- a/frontend/src/store/measuredDataStore.ts
+++ b/frontend/src/store/measuredDataStore.ts
@@ -24,13 +24,13 @@ export const MeasuredDataStore = defineStore('MeasuredDataStore', {
     /**
      * Cookieの情報を基にredisからアカウントUUIDを取得し，アカウントUUIDからマイコンリストをもらってstoreに保存
      */
-    async fetchMeasuredData(microControllerId: string) {
+    async fetchMeasuredData(microControllerUuid: string) {
       const spinnerStore = SpinnerStore();
       spinnerStore.showSpinner();
 
       let measuredDataList: MeasuredDataState;
       try {
-        measuredDataList = await fetchMeasuredData(microControllerId);
+        measuredDataList = await fetchMeasuredData(microControllerUuid);
         this.measuredDataList = measuredDataList;
       } catch (e) {
         throw e;

--- a/frontend/src/store/microControllerStore.ts
+++ b/frontend/src/store/microControllerStore.ts
@@ -1,7 +1,10 @@
-
 import { defineStore } from 'pinia';
 import { SpinnerStore } from './spinnerStore';
-import { MicroControllerInfoState, microControllerGet, microControllerRegister } from '@/methods/microController';
+import {
+  MicroControllerInfoState,
+  microControllerGet,
+  microControllerRegister,
+} from '@/methods/microController';
 
 export const MicroControllerStore = defineStore('MicroControllerStore', {
   state: () => ({
@@ -17,11 +20,16 @@ export const MicroControllerStore = defineStore('MicroControllerStore', {
      * Cookieの情報を基にredisからアカウントUUIDを取得し，アカウントUUIDからマイコンリストをもらってstoreに保存
      */
     async fetchMicroControllerList() {
-      let microControllerList: Array<MicroControllerInfoState>;
+      const spinnerStore = SpinnerStore();
+      spinnerStore.showSpinner();
+
       try {
-        microControllerList = await microControllerGet();
+        const response = await microControllerGet();
+        this.$state.microControllerList = response;
+      } catch (e) {
+        throw e;
       } finally {
-        this.$state.microControllerList = microControllerList;
+        spinnerStore.hideSpinner();
       }
     },
 

--- a/frontend/src/views/home/Home.vue
+++ b/frontend/src/views/home/Home.vue
@@ -67,8 +67,8 @@ const {
         class="micro-controller-tile"
         v-for="microController in microControllerList"
         :title="microController.name ?? '端末名称未設定'"
-        :key="microController.id"
-        @click="onClickTile(microController.id)"
+        :key="microController.uuid"
+        @click="onClickTile(microController.uuid)"
       >
         <template #content>
           <DisplayInformation title="MACアドレス" :content="microController.macAddress" />

--- a/frontend/src/views/home/composable.ts
+++ b/frontend/src/views/home/composable.ts
@@ -100,8 +100,8 @@ export const useHome = () => {
     register();
   };
 
-  const onClickTile = (id: number) => {
-    router.push({ name: 'result', params: { microControllerId: id } });
+  const onClickTile = (uuid: string) => {
+    router.push({ name: 'result', params: { microControllerUuid: uuid } });
   };
 
   return {

--- a/frontend/src/views/measuredData/MeasuredData.vue
+++ b/frontend/src/views/measuredData/MeasuredData.vue
@@ -4,6 +4,10 @@ import InformationSelect from '@/components/common/InformationSelect.vue';
 import { LineChart } from 'vue-chart-3';
 import { useMeasuredData } from './composable';
 
+const props = defineProps<{
+  microControllerUuid: string;
+}>();
+
 const {
   showNotification,
   notificationMessage,
@@ -16,7 +20,7 @@ const {
   sdi12ChartDataSet,
   onChangeEnvironmentalSelect,
   environmentalChartDataSet,
-} = useMeasuredData();
+} = useMeasuredData(props.microControllerUuid);
 </script>
 
 <template>

--- a/frontend/src/views/measuredData/composable.ts
+++ b/frontend/src/views/measuredData/composable.ts
@@ -12,9 +12,9 @@ import {
 import { NotificationType } from '@/constants/notificationType';
 import { StatusCode } from '@/constants/statusCode';
 
-export const useMeasuredData = () => {
-  const fetchMeasuredData = async () => {
-    await measuredDataStore.fetchMeasuredData(microControllerId).catch((e) => {
+export const useMeasuredData = (microControllerUuid: string) => {
+  const fetchMeasuredData = async (microControllerUuid: string) => {
+    await measuredDataStore.fetchMeasuredData(microControllerUuid).catch((e) => {
       const statusCode = e.response.status.toString();
       if (statusCode === StatusCode.INTERNAL_SERVER_ERROR) {
         notificationMessage.value = 'エラーが発生しました。時間をおいて再度お試しください。';
@@ -28,13 +28,9 @@ export const useMeasuredData = () => {
     });
   };
 
-  // Route
-  const route = useRoute();
-  const microControllerId = route.params.microControllerId[0];
-
   // Store
   const measuredDataStore = MeasuredDataStore();
-  fetchMeasuredData();
+  fetchMeasuredData(microControllerUuid);
   const microControllerStore = MicroControllerStore();
   microControllerStore.fetchMicroControllerList();
 


### PR DESCRIPTION
## 実装内容

- 測定結果確認画面のパスをUUIDに変更
- JavaのCDにて，javaの再起動を行う際にデーモン化する必要があったため，javaをservice化

## 確認手順

- ログインし，測定結果確認画面を開き，パスを確認する

## スクリーンショット

- パスがUUIDに変わっていること
<img width="1680" alt="スクリーンショット 2023-05-24 22 16 54" src="https://github.com/mktkhr/stamp-iot/assets/51685340/d6511dc4-692b-408c-bdad-1a318e16572b">


## 確認した環境

- M1 MacBook Pro
- macOS Monterey version 13.3.1
- Arduino IDE version 1.8.16

resolve #75