### PR TITLE
セッションの確認にInterceptorを使用するように変更する

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
+	testImplementation 'org.mockito:mockito-core:5.4.0'
 }
 
 test {

--- a/backend/src/main/java/com/example/stamp_app/config/AppInterceptor.java
+++ b/backend/src/main/java/com/example/stamp_app/config/AppInterceptor.java
@@ -1,0 +1,58 @@
+package com.example.stamp_app.config;
+
+import com.example.stamp_app.entity.RequestedUser;
+import com.example.stamp_app.session.RedisService;
+import com.example.stamp_app.session.SessionService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+public class AppInterceptor implements HandlerInterceptor {
+
+    @Autowired
+    SessionService sessionService;
+    @Autowired
+    RedisService redisService;
+    @Autowired
+    RequestedUser requestedUser;
+
+    /**
+     * Cookieを基に，セッションの有無を確認する
+     */
+    @Override
+    public boolean preHandle(HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull Object handler) throws ResponseStatusException {
+
+        var path = request.getRequestURI();
+
+        // セッションの有無を確認しないリクエスト
+        if (path.contains("/login") || path.contains("/register")) {
+            return true;
+        }
+
+        var cookieList = request.getCookies();
+
+        var sessionUuid = sessionService.getSessionUuidFromCookie(cookieList);
+
+        try {
+            var userUuid = redisService.getUserUuidFromSessionUuid(sessionUuid);
+            if (userUuid != null) {
+                requestedUser.setSessionUuid(sessionUuid);
+                requestedUser.setUserUuid(userUuid);
+                response.setStatus(HttpStatus.OK.value());
+                return true;
+            }
+        } catch (Exception e) {
+            log.error(e.toString());
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        response.setStatus(HttpStatus.BAD_REQUEST.value());
+        return false;
+    }
+}

--- a/backend/src/main/java/com/example/stamp_app/config/BeanConfig.java
+++ b/backend/src/main/java/com/example/stamp_app/config/BeanConfig.java
@@ -1,0 +1,12 @@
+package com.example.stamp_app.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BeanConfig {
+    @Bean
+    public AppInterceptor appInterceptor() throws Exception {
+        return new AppInterceptor();
+    }
+}

--- a/backend/src/main/java/com/example/stamp_app/config/WebMVCConfig.java
+++ b/backend/src/main/java/com/example/stamp_app/config/WebMVCConfig.java
@@ -1,0 +1,18 @@
+package com.example.stamp_app.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMVCConfig implements WebMvcConfigurer {
+
+    @Autowired
+    AppInterceptor appInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(appInterceptor);
+    }
+}

--- a/backend/src/main/java/com/example/stamp_app/controller/MeasuredDataController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/MeasuredDataController.java
@@ -2,10 +2,9 @@ package com.example.stamp_app.controller;
 
 import com.example.stamp_app.controller.param.MeasuredDataPostParam;
 import com.example.stamp_app.controller.response.measuredDataGetResponse.MeasuredDataGetResponse;
+import com.example.stamp_app.entity.RequestedUser;
 import com.example.stamp_app.service.MeasuredDataService;
 import com.example.stamp_app.session.RedisService;
-import com.example.stamp_app.session.SessionService;
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,9 +18,9 @@ public class MeasuredDataController {
     @Autowired
     MeasuredDataService measuredDataService;
     @Autowired
-    SessionService sessionService;
-    @Autowired
     RedisService redisService;
+    @Autowired
+    RequestedUser requestedUser;
 
     /**
      * 測定データ登録API
@@ -44,13 +43,9 @@ public class MeasuredDataController {
      * @return 測定結果
      */
     @GetMapping
-    public ResponseEntity<MeasuredDataGetResponse> getMeasuredData(@RequestParam String microControllerUuid, HttpServletRequest httpServletRequest) {
+    public ResponseEntity<MeasuredDataGetResponse> getMeasuredData(@RequestParam String microControllerUuid) {
 
-        var cookieLIst = httpServletRequest.getCookies();
-
-        var sessionUuid = sessionService.getSessionUuidFromCookie(cookieLIst);
-
-        var userUuid = redisService.getUserUuidFromSessionUuid(sessionUuid);
+        var userUuid = redisService.getUserUuidFromSessionUuid(requestedUser.getSessionUuid());
 
         var response = measuredDataService.getMeasuredData(userUuid, microControllerUuid);
 

--- a/backend/src/main/java/com/example/stamp_app/controller/MicroControllerController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/MicroControllerController.java
@@ -3,11 +3,11 @@ package com.example.stamp_app.controller;
 import com.example.stamp_app.controller.param.MicroControllerPostParam;
 import com.example.stamp_app.controller.response.MicroControllerGetResponse;
 import com.example.stamp_app.controller.response.MicroControllerPostResponse;
-import com.example.stamp_app.service.AccountService;
+import com.example.stamp_app.entity.RequestedUser;
 import com.example.stamp_app.service.MicroControllerService;
 import com.example.stamp_app.session.RedisService;
 import com.example.stamp_app.session.SessionService;
-import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import java.util.List;
 
 @Controller
+@Slf4j
 @RequestMapping(value = "/ems/micro-controller")
 public class MicroControllerController {
     @Autowired
@@ -28,6 +29,8 @@ public class MicroControllerController {
     SessionService sessionService;
     @Autowired
     RedisService redisService;
+    @Autowired
+    RequestedUser requestedUser;
 
     /**
      * マイコン登録API
@@ -44,17 +47,11 @@ public class MicroControllerController {
      * アカウントに紐づくマイコン一覧取得API
      */
     @GetMapping(value = "/info")
-    public ResponseEntity<List<MicroControllerGetResponse>> getMicroControllerInfo(HttpServletRequest httpServletRequest) {
+    public ResponseEntity<List<MicroControllerGetResponse>> getMicroControllerInfo() {
 
-        var cookieLIst = httpServletRequest.getCookies();
+        var userUuid = redisService.getUserUuidFromSessionUuid(requestedUser.getSessionUuid());
 
-        var sessionUuid = sessionService.getSessionUuidFromCookie(cookieLIst);
-        if(sessionUuid == null){
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        var userUuid = redisService.getUserUuidFromSessionUuid(sessionUuid);
-        if(userUuid == null){
+        if (userUuid == null) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
 

--- a/backend/src/main/java/com/example/stamp_app/controller/param/account/LoginPostParam.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/param/account/LoginPostParam.java
@@ -1,18 +1,18 @@
 package com.example.stamp_app.controller.param.account;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
 @Data
 public class LoginPostParam {
 
-    @NotNull
     @Pattern(regexp = "^([a-zA-Z0-9])+([a-zA-Z0-9._-])*@([a-zA-Z0-9_-])+([a-zA-Z0-9._-]+)+$")
+    @NotBlank
     private String email;
 
-    @NotNull
-    @Pattern(regexp = "^(?=.*[A-Z])[a-zA-Z0-9.?/-]{8,24}$")
+    // NOTE: ログイン時のパスワードはパターン推測を回避するため，パターンバリデーションを行わない
+    @NotBlank
     private String password;
 
 }

--- a/backend/src/main/java/com/example/stamp_app/controller/response/MicroControllerGetResponse.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/response/MicroControllerGetResponse.java
@@ -7,26 +7,27 @@ import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Data
 public class MicroControllerGetResponse {
 
     private BigInteger id;
 
-    private UUID uuid;
+    private String uuid;
 
     private String name;
 
     private String macAddress;
 
-    private int interval;
+    private String interval;
+
+    private String sdi12Address;
 
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
 
-    public static List<MicroControllerGetResponse> convertMicroControllerToResponse(List<MicroController> microControllerList){
+    public static List<MicroControllerGetResponse> convertMicroControllerToResponse(List<MicroController> microControllerList) {
         List<MicroControllerGetResponse> microControllerGetResponseList = new ArrayList<>();
 
         microControllerList.forEach((microController) -> {
@@ -35,9 +36,10 @@ public class MicroControllerGetResponse {
             microControllerGetResponse.setUuid(microController.getUuid());
             microControllerGetResponse.setName(microController.getName());
             microControllerGetResponse.setInterval(microController.getInterval());
+            microControllerGetResponse.setSdi12Address(microController.getSdi12Address());
             microControllerGetResponse.setMacAddress(microController.getMacAddress());
             microControllerGetResponse.setCreatedAt(microController.getCreatedAt());
-            microControllerGetResponse.setUpdatedAt(microController.getCreatedAt());
+            microControllerGetResponse.setUpdatedAt(microController.getUpdatedAt());
             microControllerGetResponseList.add(microControllerGetResponse);
         });
 

--- a/backend/src/main/java/com/example/stamp_app/entity/MicroController.java
+++ b/backend/src/main/java/com/example/stamp_app/entity/MicroController.java
@@ -1,16 +1,15 @@
 package com.example.stamp_app.entity;
 
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Comment;
 
-import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 
 
 @Entity
@@ -25,7 +24,7 @@ public class MicroController {
     @Column
     @Comment(value = "端末UUID")
     @Pattern(regexp = "^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$")
-    private UUID uuid;
+    private String uuid;
 
     @Column
     @Comment(value = "端末名")
@@ -36,15 +35,15 @@ public class MicroController {
     @Pattern(regexp = "^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
     private String macAddress;
 
-    @NotNull
     @Column
     @ColumnDefault("60")
     @Comment(value = "測定間隔(分)")
-    private int interval;
+    @Pattern(regexp = "^(60|30|20|15|10|5|1)$")
+    private String interval;
 
     @Column
     @Comment(value = "測定に使用するSDI-12アドレス(カンマ区切り)")
-    @Pattern(regexp = "^([0-9A-Za-z]{1},)*[0-9A-za-z]{1}$")
+    @Pattern(regexp = "^(([0-9A-Za-z]{1},)*[0-9A-za-z]{1})|([0-9A-za-z]{1})$")
     private String sdi12Address;
 
     @Column

--- a/backend/src/main/java/com/example/stamp_app/entity/RequestedUser.java
+++ b/backend/src/main/java/com/example/stamp_app/entity/RequestedUser.java
@@ -1,0 +1,11 @@
+package com.example.stamp_app.entity;
+
+import lombok.Data;
+import org.springframework.stereotype.Component;
+
+@Component
+@Data
+public class RequestedUser {
+    private String sessionUuid;
+    private String userUuid;
+}

--- a/backend/src/main/java/com/example/stamp_app/repository/MicroControllerRepository.java
+++ b/backend/src/main/java/com/example/stamp_app/repository/MicroControllerRepository.java
@@ -3,11 +3,8 @@ package com.example.stamp_app.repository;
 import com.example.stamp_app.entity.MicroController;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.math.BigInteger;
-import java.util.UUID;
-
-public interface MicroControllerRepository extends JpaRepository<MicroController, UUID> {
+public interface MicroControllerRepository extends JpaRepository<MicroController, String> {
     MicroController findByMacAddress(String macAddress);
 
-    MicroController findByUuid(UUID uuid);
+    MicroController findByUuid(String uuid);
 }

--- a/backend/src/main/java/com/example/stamp_app/service/MeasuredDataService.java
+++ b/backend/src/main/java/com/example/stamp_app/service/MeasuredDataService.java
@@ -127,7 +127,7 @@ public class MeasuredDataService {
         MicroController microController = null;
 
         try {
-            microController = microControllerRepository.findByUuid(UUID.fromString(microControllerUuid));
+            microController = microControllerRepository.findByUuid(microControllerUuid);
         } catch (Exception e) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/backend/src/main/java/com/example/stamp_app/service/MicroControllerService.java
+++ b/backend/src/main/java/com/example/stamp_app/service/MicroControllerService.java
@@ -1,21 +1,27 @@
 package com.example.stamp_app.service;
 
+import com.example.stamp_app.controller.param.microController.MicroControllerPatchParam;
 import com.example.stamp_app.controller.response.MicroControllerGetResponse;
 import com.example.stamp_app.controller.response.MicroControllerPostResponse;
 import com.example.stamp_app.entity.Account;
 import com.example.stamp_app.entity.MicroController;
 import com.example.stamp_app.repository.AccountRepository;
 import com.example.stamp_app.repository.MicroControllerRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigInteger;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @Service
+@Slf4j
 public class MicroControllerService {
 
     @Autowired
@@ -82,6 +88,7 @@ public class MicroControllerService {
         try {
             account = accountRepository.findByUuid(UUID.fromString(userUuid));
         } catch (Exception e) {
+            log.error(e.toString());
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 

--- a/backend/src/main/java/com/example/stamp_app/service/MicroControllerService.java
+++ b/backend/src/main/java/com/example/stamp_app/service/MicroControllerService.java
@@ -1,6 +1,5 @@
 package com.example.stamp_app.service;
 
-import com.example.stamp_app.controller.param.microController.MicroControllerPatchParam;
 import com.example.stamp_app.controller.response.MicroControllerGetResponse;
 import com.example.stamp_app.controller.response.MicroControllerPostResponse;
 import com.example.stamp_app.entity.Account;
@@ -11,13 +10,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigInteger;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
 @Service

--- a/backend/src/test/java/com/example/stamp_app/controller/account/LoginPostTest.java
+++ b/backend/src/test/java/com/example/stamp_app/controller/account/LoginPostTest.java
@@ -1,23 +1,34 @@
 package com.example.stamp_app.controller.account;
 
+import com.example.stamp_app.config.AppInterceptor;
 import com.example.stamp_app.controller.AccountController;
 import com.example.stamp_app.controller.param.account.LoginPostParam;
+import com.example.stamp_app.controller.response.AccountLoginResponse;
+import com.example.stamp_app.entity.Account;
 import com.example.stamp_app.entity.DummyData;
+import com.example.stamp_app.entity.RequestedUser;
 import com.example.stamp_app.service.AccountService;
 import com.example.stamp_app.session.RedisService;
 import com.example.stamp_app.session.SessionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AccountController.class)
@@ -25,104 +36,127 @@ public class LoginPostTest {
 
     @Autowired
     MockMvc mockMvc;
-
     @Autowired
     ObjectMapper objectMapper;
-
+    @MockBean
+    AppInterceptor appInterceptor;
+    @MockBean
+    RequestedUser requestedUser;
     @MockBean
     AccountService accountService;
-
     @MockBean
     SessionService sessionService;
-
     @MockBean
     RedisService redisService;
 
     private ResultActions mockMvcPerform(String requestBody) throws Exception {
-        return mockMvc.perform(MockMvcRequestBuilders.post(DummyData.REGISTER_POST_PATH)
+        return mockMvc.perform(MockMvcRequestBuilders.post(DummyData.LOGIN_POST_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody)
                 .accept(MediaType.APPLICATION_JSON));
     }
 
+    @BeforeEach
+    void setup() {
+        when(appInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+        var account = new Account();
+        account.setUuid(UUID.randomUUID());
+        when(accountService.login(any())).thenReturn(new AccountLoginResponse(HttpStatus.OK, account));
+        when(sessionService.generateCookie(any())).thenReturn(new Cookie("test", "cookie"));
+    }
+
     @Nested
     @DisplayName("ログインテスト")
-    class AddAccountTest {
+    class AccountLoginTest {
 
-        @Test
-        void リクエストボディのアカウントが空の場合400を返すこと() throws Exception {
-            String requestBodyString = "";
-            mockMvcPerform(requestBodyString).andExpect(status().isBadRequest());
+
+        @Nested
+        @DisplayName("メールアドレステスト")
+        class MailAddressTest {
+            @Test
+            void リクエストボディのアカウントのメールアドレスが不適切な場合400を返すこと() throws Exception {
+                LoginPostParam loginPostParam = new LoginPostParam();
+                loginPostParam.setPassword(DummyData.VALID_8_LENGTH_PASSWORD);
+                loginPostParam.setEmail(DummyData.INVALID_EMAIL_ADDRESS);
+
+                String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
+                mockMvcPerform(requestBodyString).andExpect(status().isBadRequest());
+            }
         }
 
-        @Test
-        void リクエストボディのアカウントのメールアドレスが不適切な場合400を返すこと() throws Exception {
-            LoginPostParam loginPostParam = new LoginPostParam();
-            loginPostParam.setPassword(DummyData.VALID_8_LENGTH_PASSWORD);
-            loginPostParam.setEmail(DummyData.INVALID_EMAIL_ADDRESS);
+        @Nested
+        @DisplayName("パスワードテスト(nullチェックのみ)")
+        class PasswordTest {
 
-            String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
-            mockMvcPerform(requestBodyString).andExpect(status().isBadRequest());
-        }
+            @Test
+            void リクエストボディのアカウントのパスワードがnullの場合400を返すこと() throws Exception {
+                LoginPostParam loginPostParam = new LoginPostParam();
+                loginPostParam.setEmail(DummyData.VALID_EMAIL_ADDRESS);
 
-        @Test
-        void リクエストボディのアカウントのパスワード7文字の場合400を返すこと() throws Exception {
-            LoginPostParam loginPostParam = new LoginPostParam();
-            loginPostParam.setPassword(DummyData.INVALID_7_LENGTH_PASSWORD);
-            loginPostParam.setEmail(DummyData.VALID_EMAIL_ADDRESS);
+                String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
+                mockMvcPerform(requestBodyString).andExpect(status().isBadRequest());
+            }
 
-            String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
-            mockMvcPerform(requestBodyString).andExpect(status().isBadRequest());
-        }
+            @Test
+            void リクエストボディのアカウントのパスワードが7文字の場合200を返すこと() throws Exception {
+                LoginPostParam loginPostParam = new LoginPostParam();
+                loginPostParam.setPassword(DummyData.INVALID_7_LENGTH_PASSWORD);
+                loginPostParam.setEmail(DummyData.VALID_EMAIL_ADDRESS);
 
-        @Test
-        void リクエストボディのアカウントのパスワード8文字の場合200を返すこと() throws Exception {
-            LoginPostParam loginPostParam = new LoginPostParam();
-            loginPostParam.setPassword(DummyData.VALID_8_LENGTH_PASSWORD);
-            loginPostParam.setEmail(DummyData.VALID_EMAIL_ADDRESS);
+                String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
+                mockMvcPerform(requestBodyString).andExpect(status().isOk());
+            }
 
-            String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
-            mockMvcPerform(requestBodyString).andExpect(status().isOk());
-        }
+            @Test
+            void リクエストボディのアカウントのパスワードが8文字の場合200を返すこと() throws Exception {
+                LoginPostParam loginPostParam = new LoginPostParam();
+                loginPostParam.setPassword(DummyData.VALID_8_LENGTH_PASSWORD);
+                loginPostParam.setEmail(DummyData.VALID_EMAIL_ADDRESS);
 
-        @Test
-        void リクエストボディのアカウントのパスワード9文字の場合200を返すこと() throws Exception {
-            LoginPostParam loginPostParam = new LoginPostParam();
-            loginPostParam.setPassword(DummyData.VALID_9_LENGTH_PASSWORD);
-            loginPostParam.setEmail(DummyData.VALID_EMAIL_ADDRESS);
+                String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
+                mockMvcPerform(requestBodyString).andExpect(status().isOk());
+            }
 
-            String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
-            mockMvcPerform(requestBodyString).andExpect(status().isOk());
-        }
+            @Test
+            void リクエストボディのアカウントのパスワードが9文字の場合200を返すこと() throws Exception {
+                LoginPostParam loginPostParam = new LoginPostParam();
+                loginPostParam.setPassword(DummyData.VALID_9_LENGTH_PASSWORD);
+                loginPostParam.setEmail(DummyData.VALID_EMAIL_ADDRESS);
 
-        @Test
-        void リクエストボディのアカウントのパスワード23文字の場合200を返すこと() throws Exception {
-            LoginPostParam loginPostParam = new LoginPostParam();
-            loginPostParam.setPassword(DummyData.VALID_23_LENGTH_PASSWORD);
-            loginPostParam.setEmail(DummyData.VALID_EMAIL_ADDRESS);
+                String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
+                mockMvcPerform(requestBodyString).andExpect(status().isOk());
+            }
 
-            String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
-            mockMvcPerform(requestBodyString).andExpect(status().isOk());
-        }
+            @Test
+            void リクエストボディのアカウントのパスワードが23文字の場合200を返すこと() throws Exception {
+                LoginPostParam loginPostParam = new LoginPostParam();
+                loginPostParam.setPassword(DummyData.VALID_23_LENGTH_PASSWORD);
+                loginPostParam.setEmail(DummyData.VALID_EMAIL_ADDRESS);
 
-        @Test
-        void リクエストボディのアカウントのパスワード24文字の場合200を返すこと() throws Exception {
-            LoginPostParam loginPostParam = new LoginPostParam();
-            loginPostParam.setPassword(DummyData.VALID_24_LENGTH_PASSWORD);
-            loginPostParam.setEmail(DummyData.VALID_EMAIL_ADDRESS);
+                String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
+                mockMvcPerform(requestBodyString).andExpect(status().isOk());
+            }
 
-            String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
-            mockMvcPerform(requestBodyString).andExpect(status().isOk());
-        }
+            @Test
+            void リクエストボディのアカウントのパスワードが24文字の場合200を返すこと() throws Exception {
+                LoginPostParam loginPostParam = new LoginPostParam();
+                loginPostParam.setPassword(DummyData.VALID_24_LENGTH_PASSWORD);
+                loginPostParam.setEmail(DummyData.VALID_EMAIL_ADDRESS);
 
-        @Test
-        void リクエストボディのアカウントのパスワード25文字の場合400を返すこと() throws Exception {
-            LoginPostParam loginPostParam = new LoginPostParam();
-            loginPostParam.setPassword(DummyData.INVALID_25_LENGTH_PASSWORD);
-            loginPostParam.setEmail(DummyData.VALID_EMAIL_ADDRESS);
+                String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
+                mockMvcPerform(requestBodyString).andExpect(status().isOk());
+            }
 
-            String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
-            mockMvcPerform(requestBodyString).andExpect(status().isBadRequest());
+            @Test
+            void リクエストボディのアカウントのパスワードが25文字の場合200を返すこと() throws Exception {
+                LoginPostParam loginPostParam = new LoginPostParam();
+                loginPostParam.setPassword(DummyData.INVALID_25_LENGTH_PASSWORD);
+                loginPostParam.setEmail(DummyData.VALID_EMAIL_ADDRESS);
+
+                String requestBodyString = objectMapper.writeValueAsString(loginPostParam);
+                mockMvcPerform(requestBodyString).andExpect(status().isOk());
+            }
         }
     }
 }

--- a/backend/src/test/java/com/example/stamp_app/controller/account/RegisterPostTest.java
+++ b/backend/src/test/java/com/example/stamp_app/controller/account/RegisterPostTest.java
@@ -1,12 +1,15 @@
 package com.example.stamp_app.controller.account;
 
+import com.example.stamp_app.config.AppInterceptor;
 import com.example.stamp_app.controller.AccountController;
 import com.example.stamp_app.controller.param.account.RegisterPostParam;
 import com.example.stamp_app.entity.DummyData;
+import com.example.stamp_app.entity.RequestedUser;
 import com.example.stamp_app.service.AccountService;
 import com.example.stamp_app.session.RedisService;
 import com.example.stamp_app.session.SessionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,6 +21,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AccountController.class)
@@ -25,9 +30,12 @@ public class RegisterPostTest {
 
     @Autowired
     MockMvc mockMvc;
-
     @Autowired
     ObjectMapper objectMapper;
+    @MockBean
+    AppInterceptor appInterceptor;
+    @MockBean
+    RequestedUser requestedUser;
 
     @MockBean
     AccountService accountService;
@@ -43,6 +51,11 @@ public class RegisterPostTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody)
                 .accept(MediaType.APPLICATION_JSON));
+    }
+
+    @BeforeEach
+    void setup() {
+        when(appInterceptor.preHandle(any(), any(), any())).thenReturn(true);
     }
 
     @Nested

--- a/backend/src/test/java/com/example/stamp_app/entity/DummyData.java
+++ b/backend/src/test/java/com/example/stamp_app/entity/DummyData.java
@@ -2,6 +2,7 @@ package com.example.stamp_app.entity;
 
 public class DummyData {
     public static final String REGISTER_POST_PATH = "/ems/account/register";
+    public static final String LOGIN_POST_PATH = "/ems/account/login";
 
     public static final String INVALID_7_LENGTH_PASSWORD = "A123456";
 
@@ -22,4 +23,8 @@ public class DummyData {
     public static final String VALID_EMAIL_ADDRESS = "aaa@example.com";
 
     public static final String INVALID_EMAIL_ADDRESS = "aaaexample.com";
+    public static final String INVALID_UUID = "a";
+    public static final String VALID_UUID = "4e540b38-31f8-40b4-9602-44dea41e5c5a";
+    public static final String INVALID_INTERVAL = "100";
+    public static final String INVALID_SDI_ADDRESS = "11";
 }


### PR DESCRIPTION
## 実装内容

- セッションの確認をInterceptorで行うように修正

## 確認手順

- セッションを使用するAPI実行時に，Interceptorで処理が行われていることを確認する


## 確認した環境

- M1 MacBook Pro
- macOS Monterey version 13.3.1
- Arduino IDE version 1.8.16

resolve #80 