### PR TITLE
セッション確認APIにてセッションが無効だった場合に400を返さないようにする

### DIFF
--- a/backend/src/main/java/com/example/stamp_app/config/AppInterceptor.java
+++ b/backend/src/main/java/com/example/stamp_app/config/AppInterceptor.java
@@ -48,7 +48,7 @@ public class AppInterceptor implements HandlerInterceptor {
                 return true;
             }
         } catch (Exception e) {
-            log.error(e.toString());
+            log.error(e.getMessage(), e);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 

--- a/backend/src/main/java/com/example/stamp_app/config/AppInterceptor.java
+++ b/backend/src/main/java/com/example/stamp_app/config/AppInterceptor.java
@@ -31,7 +31,7 @@ public class AppInterceptor implements HandlerInterceptor {
         var path = request.getRequestURI();
 
         // セッションの有無を確認しないリクエスト
-        if (path.contains("/login") || path.contains("/register")) {
+        if (path.contains("/login") || path.contains("/register") || path.contains("/session")) {
             return true;
         }
 

--- a/backend/src/main/java/com/example/stamp_app/controller/SessionController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/SessionController.java
@@ -2,16 +2,15 @@ package com.example.stamp_app.controller;
 
 import com.example.stamp_app.session.RedisService;
 import com.example.stamp_app.session.SessionService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 @Controller
 @RequestMapping(value = "/ems/session")
@@ -29,22 +28,26 @@ public class SessionController {
      * @return ResponseEntity
      */
     @PostMapping
-    public ResponseEntity<HttpStatus> addAccount(HttpServletRequest request, HttpServletResponse httpServletResponse) {
+    public ResponseEntity<String> addAccount(HttpServletRequest request, HttpServletResponse httpServletResponse) {
 
         var cookieList = request.getCookies();
 
         String sessionUuid = sessionService.getSessionUuidFromCookie(cookieList);
 
+        if (sessionUuid == null) {
+            return new ResponseEntity<>("failed", HttpStatus.OK);
+        }
+
         String UserUuid = redisService.getUserUuidFromSessionUuid(sessionUuid);
 
         if (UserUuid == null) {
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>("failed", HttpStatus.OK);
         } else {
             // 有効期限が更新されたCookieを生成してレスポンスに追加
             Cookie cookie = sessionService.generateCookie(sessionUuid);
             httpServletResponse.addCookie(cookie);
 
-            return new ResponseEntity<>(HttpStatus.OK);
+            return new ResponseEntity<>("success", HttpStatus.OK);
         }
     }
 }

--- a/backend/src/main/java/com/example/stamp_app/service/AccountService.java
+++ b/backend/src/main/java/com/example/stamp_app/service/AccountService.java
@@ -36,7 +36,7 @@ public class AccountService {
         try {
             isNewUser = accountRepository.findByEmail(registerPostParam.getEmail()) == null;
         } catch (Exception e) {
-            log.error(e.getMessage());
+            log.error(e.getMessage(), e);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
@@ -56,8 +56,8 @@ public class AccountService {
 
         try {
             accountRepository.save(newUser);
-        } catch (Exception exception) {
-            log.error(exception.getMessage());
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
@@ -78,7 +78,7 @@ public class AccountService {
             loginUser = accountRepository.findByEmail(loginPostParam.getEmail());
 
         } catch (Exception e) {
-            log.error(e.getMessage());
+            log.error(e.getMessage(), e);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
@@ -121,7 +121,7 @@ public class AccountService {
             }
 
         } catch (Exception e) {
-            log.error(e.getMessage());
+            log.error(e.getMessage(), e);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 

--- a/backend/src/main/java/com/example/stamp_app/service/MeasuredDataService.java
+++ b/backend/src/main/java/com/example/stamp_app/service/MeasuredDataService.java
@@ -56,7 +56,7 @@ public class MeasuredDataService {
             microController = microControllerRepository.findByMacAddress(measuredDataPostParam.getMacAddress());
 
         } catch (Exception e) {
-            log.error(e.toString());
+            log.error(e.getMessage(), e);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
@@ -110,7 +110,7 @@ public class MeasuredDataService {
             }
 
         } catch (Exception e) {
-            log.error(e.toString());
+            log.error(e.getMessage(), e);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 

--- a/backend/src/main/java/com/example/stamp_app/service/MicroControllerService.java
+++ b/backend/src/main/java/com/example/stamp_app/service/MicroControllerService.java
@@ -87,7 +87,7 @@ public class MicroControllerService {
         try {
             account = accountRepository.findByUuid(UUID.fromString(userUuid));
         } catch (Exception e) {
-            log.error(e.toString());
+            log.error(e.getMessage(), e);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
@@ -169,7 +169,7 @@ public class MicroControllerService {
         try {
             microControllerRepository.save(microController);
         } catch (Exception e) {
-            log.error(e.toString());
+            log.error(e.getMessage(), e);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
@@ -177,7 +177,7 @@ public class MicroControllerService {
         try {
             microControllerUpdateResult = microControllerRepository.findByUuid(param.getMicroControllerUuid());
         } catch (Exception e) {
-            log.error(e.toString());
+            log.error(e.getMessage(), e);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 

--- a/backend/src/main/java/com/example/stamp_app/session/SessionService.java
+++ b/backend/src/main/java/com/example/stamp_app/session/SessionService.java
@@ -1,14 +1,12 @@
 package com.example.stamp_app.session;
 
+import jakarta.servlet.http.Cookie;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-import jakarta.servlet.http.Cookie;
-import org.springframework.web.server.ResponseStatusException;
-
-import static com.example.stamp_app.constants.Constants.*;
+import static com.example.stamp_app.constants.Constants.COOKIE_NAME;
+import static com.example.stamp_app.constants.Constants.SESSION_VALID_TIME_IN_SEC;
 
 @Service
 public class SessionService {
@@ -62,10 +60,6 @@ public class SessionService {
                     sessionUuid = cookie.getValue();
                 }
             }
-        }
-
-        if(sessionUuid == null){
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
         }
 
         return sessionUuid;

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -80,7 +80,7 @@ const checkSession = async (): Promise<boolean> => {
   await axios
     .post('/api/ems/session')
     .then((response) => {
-      if (response.status === 200) {
+      if (response.data.toString() ===  'success') {
         sessionStatus = true;
       } else {
         sessionStatus = false;


### PR DESCRIPTION
## 実装内容

- セッション無効時も200を返し，フロントはレスポンスに応じて有効性をチェックするように修正

## 確認手順

- ブラウザにてlocalhostにアクセスし，ログアウトする
- ログアウト後のセッションapiのレスポンスを確認する

## スクリーンショット

- 

## 確認した環境

- M1 MacBook Pro
- macOS Monterey version 13.3.1
- Arduino IDE version 1.8.16

resolve #86 