### PR TITLE
API仕様書を作成する

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,12 @@
 
 1. Java17 をインストール ([Oracle](https://www.oracle.com/jp/java/technologies/downloads/#java17), [Amazon Corretto](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/downloads-list.html))
 2. `stamp-iot/backend` へ移動
-3. InntelliJ で `BackendApplication` を実行
+3. IntelliJ で `BackendApplication` を実行
 
 ### データベース
 1. 初期テーブルはjpaにより自動で生成されるため，作成する必要はなし
+
+### API仕様書の更新
+1. バックエンドを起動
+2. `localhost:8082/api-docs.yaml` にアクセスし，`api-docs.yaml` をダウンロード
+3. `/document/API仕様/api-docs.yaml` を置換

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -16,6 +16,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// springdoc
+	implementation'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/backend/src/main/java/com/example/stamp_app/BackendApplication.java
+++ b/backend/src/main/java/com/example/stamp_app/BackendApplication.java
@@ -1,9 +1,21 @@
 package com.example.stamp_app;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@OpenAPIDefinition(
+		servers = {
+				@Server(url = "http://localhost:8080", description = "ローカル環境"),
+				@Server(url = "https://www.ems-engineering.jp", description = "本番環境")
+		},
+		info = @Info(
+				title = "Stamp IoT API仕様書",
+				description = "Stamp IoT用バックエンドアプリ",
+				version = "v1"))
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/example/stamp_app/config/AppInterceptor.java
+++ b/backend/src/main/java/com/example/stamp_app/config/AppInterceptor.java
@@ -8,9 +8,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Objects;
 
 @Slf4j
 public class AppInterceptor implements HandlerInterceptor {
@@ -21,6 +24,8 @@ public class AppInterceptor implements HandlerInterceptor {
     RedisService redisService;
     @Autowired
     RequestedUser requestedUser;
+    @Value("${spring.profiles.active}")
+    String activeProfile;
 
     /**
      * Cookieを基に，セッションの有無を確認する
@@ -29,6 +34,11 @@ public class AppInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull Object handler) throws ResponseStatusException {
 
         var path = request.getRequestURI();
+
+        // アクティブプロファイルがdevかつspringdoc用エンドポイントへのアクセスの場合
+        if (Objects.equals(activeProfile, "dev") && (path.contains("/swagger-ui") || path.contains("/api-docs"))) {
+            return true;
+        }
 
         // セッションの有無を確認しないリクエスト
         if (path.contains("/login") || path.contains("/register") || path.contains("/session")) {

--- a/backend/src/main/java/com/example/stamp_app/controller/AccountController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/AccountController.java
@@ -13,18 +13,14 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
 import static com.example.stamp_app.constants.Constants.SESSION_VALID_TIME_IN_SEC;
 
-@Controller
+@RestController
 @RequestMapping(value = "/ems/account")
 public class AccountController {
     @Autowired

--- a/backend/src/main/java/com/example/stamp_app/controller/AccountController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/AccountController.java
@@ -8,8 +8,15 @@ import com.example.stamp_app.entity.RequestedUser;
 import com.example.stamp_app.service.AccountService;
 import com.example.stamp_app.session.RedisService;
 import com.example.stamp_app.session.SessionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +28,7 @@ import java.util.UUID;
 import static com.example.stamp_app.constants.Constants.SESSION_VALID_TIME_IN_SEC;
 
 @RestController
+@Tag(name = "Account", description = "アカウント関連API")
 @RequestMapping(value = "/ems/account")
 public class AccountController {
     @Autowired
@@ -38,8 +46,18 @@ public class AccountController {
      * @param registerPostParam 登録情報
      * @return ResponseEntity
      */
+    @Operation(summary = "アカウント登録API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "登録成功", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class))),
+            @ApiResponse(responseCode = "400", description = "バリデーションエラー", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
+    })
     @PostMapping(value = "/register")
-    public ResponseEntity<HttpStatus> addAccount(@RequestBody @Validated RegisterPostParam registerPostParam) {
+    public ResponseEntity<HttpStatus> addAccount(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "登録情報", content = {
+                    @Content(schema = @Schema(implementation = RegisterPostParam.class))
+            })
+            @RequestBody
+            @Validated RegisterPostParam registerPostParam) {
 
         accountService.addAccount(registerPostParam);
 
@@ -52,8 +70,19 @@ public class AccountController {
      * @param loginPostParam 登録情報
      * @return ResponseEntity
      */
+    @Operation(summary = "ログインAPI")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "ログイン成功", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class))),
+            @ApiResponse(responseCode = "400", description = "バリデーションエラー", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class))),
+            @ApiResponse(responseCode = "401", description = "認証エラー", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
+    })
     @PostMapping(value = "/login")
-    public ResponseEntity<HttpStatus> login(@RequestBody @Validated LoginPostParam loginPostParam, HttpServletResponse httpServletResponse) {
+    public ResponseEntity<HttpStatus> login(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "ログイン情報", content = {
+                    @Content(schema = @Schema(implementation = LoginPostParam.class))
+            })
+            @RequestBody
+            @Validated LoginPostParam loginPostParam, HttpServletResponse httpServletResponse) {
 
         AccountLoginResponse accountLoginResponse = accountService.login(loginPostParam);
 
@@ -74,6 +103,10 @@ public class AccountController {
      *
      * @return ResponseEntity
      */
+    @Operation(summary = "ログアウトAPI")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "ログアウト成功", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
+    })
     @PostMapping(value = "/logout")
     public ResponseEntity<HttpStatus> logout(HttpServletResponse httpServletResponse) {
 
@@ -92,6 +125,11 @@ public class AccountController {
      *
      * @return ユーザーIDとユーザー名
      */
+    @Operation(summary = "アカウント詳細取得API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "ログイン成功", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AccountGetResponse.class))),
+            @ApiResponse(responseCode = "400", description = "バリデーションエラー", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
+    })
     @GetMapping(value = "/info")
     public ResponseEntity<AccountGetResponse> accountInfo() {
 

--- a/backend/src/main/java/com/example/stamp_app/controller/MeasuredDataController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/MeasuredDataController.java
@@ -9,11 +9,10 @@ import jakarta.validation.constraints.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
 @Validated
 @RequestMapping(value = "/ems/measured-data")
 public class MeasuredDataController {

--- a/backend/src/main/java/com/example/stamp_app/controller/MeasuredDataController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/MeasuredDataController.java
@@ -5,7 +5,15 @@ import com.example.stamp_app.controller.response.measuredDataGetResponse.Measure
 import com.example.stamp_app.entity.RequestedUser;
 import com.example.stamp_app.service.MeasuredDataService;
 import com.example.stamp_app.session.RedisService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Pattern;
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Validated
+@Tag(name = "MeasuredData", description = "測定結果関連API")
 @RequestMapping(value = "/ems/measured-data")
 public class MeasuredDataController {
 
@@ -30,8 +39,20 @@ public class MeasuredDataController {
      * @param measuredDataPostParam 測定データ
      * @return ResponseEntity
      */
+    @Operation(summary = "測定データ登録API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "登録成功", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class))),
+            @ApiResponse(responseCode = "400", description = "バリデーションエラー", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class))),
+            @ApiResponse(responseCode = "401", description = "認証エラー", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class))),
+            @ApiResponse(responseCode = "403", description = "無効なマイコン", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
+    })
     @PostMapping
-    public ResponseEntity<HttpStatus> addMeasuredData(@RequestBody @Validated MeasuredDataPostParam measuredDataPostParam) {
+    public ResponseEntity<HttpStatus> addMeasuredData(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "登録情報", content = {
+                    @Content(schema = @Schema(implementation = MeasuredDataPostParam.class))
+            })
+            @RequestBody
+            @Validated MeasuredDataPostParam measuredDataPostParam) {
 
         measuredDataService.addMeasuredData(measuredDataPostParam);
 
@@ -44,8 +65,17 @@ public class MeasuredDataController {
      * @param microControllerUuid マイコンID
      * @return 測定結果
      */
+    @Operation(summary = "測定データ取得API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "取得成功", content = @Content(schema = @Schema(implementation = MeasuredDataGetResponse.class))),
+            @ApiResponse(responseCode = "400", description = "バリデーションエラー", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class))),
+            @ApiResponse(responseCode = "403", description = "マイコン所有者不一致エラー", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
+    })
     @GetMapping
-    public ResponseEntity<MeasuredDataGetResponse> getMeasuredData(@RequestParam @Pattern(regexp = "^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$") String microControllerUuid) {
+    public ResponseEntity<MeasuredDataGetResponse> getMeasuredData(
+            @Parameter(required = true, description = "マイコンUUID", example = "61d5f7a7-7629-496e-be68-cfe022264578")
+            @RequestParam
+            @Pattern(regexp = "^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$") String microControllerUuid) {
 
         var userUuid = redisService.getUserUuidFromSessionUuid(requestedUser.getSessionUuid());
 

--- a/backend/src/main/java/com/example/stamp_app/controller/MicroControllerController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/MicroControllerController.java
@@ -14,13 +14,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Controller
+@RestController
 @Slf4j
 @Validated
 @RequestMapping(value = "/ems/micro-controller")

--- a/backend/src/main/java/com/example/stamp_app/controller/MicroControllerController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/MicroControllerController.java
@@ -6,13 +6,21 @@ import com.example.stamp_app.controller.response.MicroControllerGetResponse;
 import com.example.stamp_app.controller.response.MicroControllerPostResponse;
 import com.example.stamp_app.entity.RequestedUser;
 import com.example.stamp_app.service.MicroControllerService;
-import com.example.stamp_app.session.RedisService;
-import com.example.stamp_app.session.SessionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -22,31 +30,44 @@ import java.util.List;
 @RestController
 @Slf4j
 @Validated
+@Tag(name = "MicroController", description = "マイコン関連API")
 @RequestMapping(value = "/ems/micro-controller")
 public class MicroControllerController {
     @Autowired
     MicroControllerService microControllerService;
-    @Autowired
-    SessionService sessionService;
-    @Autowired
-    RedisService redisService;
     @Autowired
     RequestedUser requestedUser;
 
     /**
      * マイコン登録API
      */
+    @Operation(summary = "マイコン登録API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "登録成功", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MicroControllerPostResponse.class))),
+            @ApiResponse(responseCode = "400", description = "バリデーションエラー/無効なマイコン", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class))),
+            @ApiResponse(responseCode = "401", description = "認証エラー", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
+    })
     @PostMapping
-    public ResponseEntity<String> addMicroControllerRelation(@RequestBody @Validated MicroControllerPostParam microControllerPostParam) {
+    public ResponseEntity<MicroControllerPostResponse> addMicroControllerRelation(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "マイコン登録パラメータ", content = {
+                    @Content(schema = @Schema(implementation = MicroControllerPostParam.class))
+            })
+            @RequestBody
+            @Validated MicroControllerPostParam microControllerPostParam) {
 
         MicroControllerPostResponse microControllerPostResponse = microControllerService.addMicroControllerRelation(microControllerPostParam.getUserId(), microControllerPostParam.getMacAddress());
 
-        return new ResponseEntity<>(microControllerPostResponse.getMicroController().getMacAddress(), microControllerPostResponse.getStatus());
+        return new ResponseEntity<>(microControllerPostResponse, HttpStatus.OK);
     }
 
     /**
      * アカウントに紐づくマイコン一覧取得API
      */
+    @Operation(summary = "マイコン一覧取得API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "取得成功", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, array = @ArraySchema(schema = @Schema(implementation = MicroControllerGetResponse.class)))),
+            @ApiResponse(responseCode = "400", description = "無効なアカウント", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
+    })
     @GetMapping(value = "/info")
     public ResponseEntity<List<MicroControllerGetResponse>> getMicroControllerInfo() {
 
@@ -60,9 +81,16 @@ public class MicroControllerController {
      *
      * @param microControllerUuid マイコンUUID
      */
-
+    @Operation(summary = "マイコン詳細取得API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "取得成功", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, array = @ArraySchema(schema = @Schema(implementation = MicroControllerGetResponse.class)))),
+            @ApiResponse(responseCode = "400", description = "無効なアカウント", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
+    })
     @GetMapping(value = "/detail")
-    public ResponseEntity<MicroControllerGetResponse> getMicroControllerDetail(@RequestParam @Pattern(regexp = "^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$") String microControllerUuid) {
+    public ResponseEntity<MicroControllerGetResponse> getMicroControllerDetail(
+            @Parameter(required = true, description = "マイコンUUID", example = "61d5f7a7-7629-496e-be68-cfe022264578")
+            @RequestParam
+            @Pattern(regexp = "^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$") String microControllerUuid) {
         var microController = microControllerService.getMicroControllerDetail(microControllerUuid);
         var response = MicroControllerGetResponse.convertMicroControllerToDetailResponse(microController);
 
@@ -75,8 +103,18 @@ public class MicroControllerController {
      *
      * @param param 更新パラメータ
      */
+    @Operation(summary = "マイコン詳細更新API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "取得成功", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, array = @ArraySchema(schema = @Schema(implementation = MicroControllerGetResponse.class)))),
+            @ApiResponse(responseCode = "400", description = "無効なアカウント", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
+    })
     @PatchMapping(value = "/detail")
-    public ResponseEntity<MicroControllerGetResponse> updateMicroControllerDetail(@Valid @Validated @RequestBody MicroControllerPatchParam param) {
+    public ResponseEntity<MicroControllerGetResponse> updateMicroControllerDetail(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "マイコン詳細更新パラメータ", content = {
+                    @Content(schema = @Schema(implementation = MicroControllerPatchParam.class))
+            })
+            @Valid @Validated
+            @RequestBody MicroControllerPatchParam param) {
 
         var microController = microControllerService.updateMicroControllerDetail(requestedUser.getUserUuid(), param);
         var response = MicroControllerGetResponse.convertMicroControllerToDetailResponse(microController);

--- a/backend/src/main/java/com/example/stamp_app/controller/SessionController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/SessionController.java
@@ -8,11 +8,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequestMapping(value = "/ems/session")
 public class SessionController {
 

--- a/backend/src/main/java/com/example/stamp_app/controller/SessionController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/SessionController.java
@@ -2,6 +2,12 @@ package com.example.stamp_app.controller;
 
 import com.example.stamp_app.session.RedisService;
 import com.example.stamp_app.session.SessionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -13,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "Session", description = "セッション関連API")
 @RequestMapping(value = "/ems/session")
 public class SessionController {
 
@@ -27,8 +34,15 @@ public class SessionController {
      * @param request リクエスト内容
      * @return ResponseEntity
      */
+    @Operation(summary = "セッション確認API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "確認成功", content = @Content(examples = {
+                    @ExampleObject(name = "セッション有効", value = "success"),
+                    @ExampleObject(name = "セッション無効", value = "failed")
+            }))
+    })
     @PostMapping
-    public ResponseEntity<String> addAccount(HttpServletRequest request, HttpServletResponse httpServletResponse) {
+    public ResponseEntity<String> checkSession(HttpServletRequest request, HttpServletResponse httpServletResponse) {
 
         var cookieList = request.getCookies();
 

--- a/backend/src/main/java/com/example/stamp_app/controller/param/EnvironmentalDataParam.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/param/EnvironmentalDataParam.java
@@ -1,20 +1,28 @@
 package com.example.stamp_app.controller.param;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
+@Schema(description = "環境データパラメータ")
 public class EnvironmentalDataParam {
 
+    @Schema(description = "大気圧", example = "1011.11")
     private String airPress;
 
+    @Schema(description = "気温", example = "11.11")
     private String temp;
 
+    @Schema(description = "相対湿度", example = "77.77")
     private String humi;
 
+    @Schema(description = "二酸化炭素濃度", example = "1111.11")
     private String co2Concent;
 
+    @Schema(description = "総揮発性有機化合物", example = "11.11")
     private String tvoc;
 
+    @Schema(description = "アナログ値", example = "11.11")
     private String analogValue;
 
 }

--- a/backend/src/main/java/com/example/stamp_app/controller/param/MeasuredDataPostParam.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/param/MeasuredDataPostParam.java
@@ -1,5 +1,6 @@
 package com.example.stamp_app.controller.param;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
@@ -7,15 +8,20 @@ import lombok.Data;
 import java.util.List;
 
 @Data
+@Schema(description = "測定結果登録パラメータ")
 public class MeasuredDataPostParam {
 
     @NotBlank
+    @Schema(description = "MACアドレス", example = "AA:AA:AA:AA:AA:AA")
     @Pattern(regexp = "^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
     private String macAddress;
 
+    @Schema(description = "SDI-12パラメータリスト")
     private List<Sdi12Param> sdi12Param;
 
+    @Schema(description = "環境データパラメータリスト")
     private List<EnvironmentalDataParam> environmentalDataParam;
 
+    @Schema(description = "電圧", example = "11.11")
     private String voltage;
 }

--- a/backend/src/main/java/com/example/stamp_app/controller/param/MicroControllerPostParam.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/param/MicroControllerPostParam.java
@@ -1,5 +1,6 @@
 package com.example.stamp_app.controller.param;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -7,13 +8,16 @@ import jakarta.validation.constraints.Positive;
 import lombok.Data;
 
 @Data
+@Schema(description = "マイコン登録パラメータ")
 public class MicroControllerPostParam {
 
     @NotNull
     @Positive
+    @Schema(description = "ユーザーID")
     private Long userId;
 
     @NotBlank
+    @Schema(description = "MACアドレス")
     @Pattern(regexp = "^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$")
     private String macAddress;
 

--- a/backend/src/main/java/com/example/stamp_app/controller/param/Sdi12Param.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/param/Sdi12Param.java
@@ -1,30 +1,42 @@
 package com.example.stamp_app.controller.param;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
+@Schema(description = "SDI-12パラメータ")
 public class Sdi12Param {
 
+    @Schema(description = "センサID", example = "1")
     private Long sensorId;
 
     @NotNull
+    @Schema(description = "SDI-12アドレス", example = "1")
     private String sdiAddress;
 
+    @Schema(description = "体積含水率", example = "11.11")
     private String vwc;
 
+    @Schema(description = "地温", example = "11.11")
     private String soilTemp;
 
+    @Schema(description = "比誘電率", example = "11.11")
     private String brp;
 
+    @Schema(description = "電気伝導度", example = "11.11")
     private String sbec;
 
+    @Schema(description = "間隙水電気伝導度", example = "11.11")
     private String spwec;
 
+    @Schema(description = "重力加速度(X)", example = "1.11")
     private String gax;
 
+    @Schema(description = "重力加速度(Y)", example = "1.11")
     private String gay;
 
+    @Schema(description = "重力加速度(Z)", example = "1.11")
     private String gaz;
 
 }

--- a/backend/src/main/java/com/example/stamp_app/controller/param/account/LoginPostParam.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/param/account/LoginPostParam.java
@@ -1,18 +1,22 @@
 package com.example.stamp_app.controller.param.account;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
 @Data
+@Schema(description = "ログインパラメータ")
 public class LoginPostParam {
 
-    @Pattern(regexp = "^([a-zA-Z0-9])+([a-zA-Z0-9._-])*@([a-zA-Z0-9_-])+([a-zA-Z0-9._-]+)+$")
     @NotBlank
+    @Schema(description = "メールアドレス", example = "aaa@example.com")
+    @Pattern(regexp = "^([a-zA-Z0-9])+([a-zA-Z0-9._-])*@([a-zA-Z0-9_-])+([a-zA-Z0-9._-]+)+$")
     private String email;
 
     // NOTE: ログイン時のパスワードはパターン推測を回避するため，パターンバリデーションを行わない
     @NotBlank
+    @Schema(description = "パスワード", example = "SamplePassword")
     private String password;
 
 }

--- a/backend/src/main/java/com/example/stamp_app/controller/param/account/RegisterPostParam.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/param/account/RegisterPostParam.java
@@ -1,17 +1,21 @@
 package com.example.stamp_app.controller.param.account;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
 @Data
+@Schema(description = "アカウント登録パラメータ")
 public class RegisterPostParam {
 
     @NotNull
+    @Schema(description = "メールアドレス", example = "aaa@example.com")
     @Pattern(regexp = "^([a-zA-Z0-9])+([a-zA-Z0-9._-])*@([a-zA-Z0-9_-])+([a-zA-Z0-9._-]+)+$")
     private String email;
 
     @NotNull
+    @Schema(description = "パスワード", example = "SamplePassword")
     @Pattern(regexp = "^(?=.*[A-Z])[a-zA-Z0-9.?/-]{8,24}$")
     private String password;
 

--- a/backend/src/main/java/com/example/stamp_app/controller/param/microController/MicroControllerPatchParam.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/param/microController/MicroControllerPatchParam.java
@@ -1,5 +1,6 @@
 package com.example.stamp_app.controller.param.microController;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -9,21 +10,26 @@ import org.springframework.validation.annotation.Validated;
 
 
 @Getter
+@Schema(description = "マイコン更新データ")
 @AllArgsConstructor
 @Validated
 public class MicroControllerPatchParam {
 
-    @Pattern(regexp = "^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$")
     @NotNull
+    @Schema(description = "マイコンUUID", example = "61d5f7a7-7629-496e-be68-cfe022264578")
+    @Pattern(regexp = "^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$")
     private String microControllerUuid;
 
+    @Schema(description = "マイコン名", example = "サンプル端末")
     private String name;
 
-    @Pattern(regexp = "^(60|30|20|15|10|5|1)$")
     @NotNull
+    @Schema(description = "測定間隔", example = "60")
+    @Pattern(regexp = "^(60|30|20|15|10|5|1)$")
     private String interval;
 
-    @Pattern(regexp = "^(([0-9A-Za-z]{1},)*[0-9A-za-z]{1})|([0-9A-za-z]{1})$")
     @Nullable
+    @Schema(description = "SDI-12アドレス", example = "1,3")
+    @Pattern(regexp = "^(([0-9A-Za-z]{1},)*[0-9A-za-z]{1})|([0-9A-za-z]{1})$")
     private String sdi12Address;
 }

--- a/backend/src/main/java/com/example/stamp_app/controller/response/AccountGetResponse.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/response/AccountGetResponse.java
@@ -17,10 +17,10 @@ public class AccountGetResponse {
     @Schema(description = "登録名", example = "サンプル太郎")
     private String name;
 
-    @Schema(description = "作成日", example = "2023-01-01T01:01:01.111111")
+    @Schema(description = "作成日時", example = "2023-01-01T01:01:01.111111")
     private LocalDateTime createdAt;
 
-    @Schema(description = "更新日", example = "2023-01-01T01:01:01.111111")
+    @Schema(description = "更新日時", example = "2023-01-01T01:01:01.111111")
     private LocalDateTime updatedAt;
 
 }

--- a/backend/src/main/java/com/example/stamp_app/controller/response/AccountGetResponse.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/response/AccountGetResponse.java
@@ -1,5 +1,6 @@
 package com.example.stamp_app.controller.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -7,14 +8,19 @@ import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor
+@Schema(description = "アカウント情報")
 public class AccountGetResponse {
 
+    @Schema(description = "アカウントID", example = "1")
     private Long id;
 
+    @Schema(description = "登録名", example = "サンプル太郎")
     private String name;
 
+    @Schema(description = "作成日", example = "2023-01-01T01:01:01.111111")
     private LocalDateTime createdAt;
 
+    @Schema(description = "更新日", example = "2023-01-01T01:01:01.111111")
     private LocalDateTime updatedAt;
 
 }

--- a/backend/src/main/java/com/example/stamp_app/controller/response/MicroControllerGetResponse.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/response/MicroControllerGetResponse.java
@@ -1,6 +1,8 @@
 package com.example.stamp_app.controller.response;
 
 import com.example.stamp_app.entity.MicroController;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -8,22 +10,32 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
+@Schema(description = "マイコン詳細データ")
+@AllArgsConstructor
 public class MicroControllerGetResponse {
 
+    @Schema(description = "マイコンID", example = "1")
     private Long id;
 
+    @Schema(description = "マイコンUUID", example = "61d5f7a7-7629-496e-be68-cfe022264578")
     private String uuid;
 
+    @Schema(description = "マイコン名", example = "サンプル端末")
     private String name;
 
+    @Schema(description = "MACアドレス", example = "AA:AA:AA:AA:AA:AA")
     private String macAddress;
 
+    @Schema(description = "測定間隔", example = "60")
     private String interval;
 
+    @Schema(description = "SDI-12アドレス", example = "1,3")
     private String sdi12Address;
 
+    @Schema(description = "作成日時", example = "2023-01-01T01:01:01.111111")
     private LocalDateTime createdAt;
 
+    @Schema(description = "更新日時", example = "2023-01-01T01:01:01.111111")
     private LocalDateTime updatedAt;
 
 
@@ -31,7 +43,16 @@ public class MicroControllerGetResponse {
         List<MicroControllerGetResponse> microControllerGetResponseList = new ArrayList<>();
 
         microControllerList.forEach((microController) -> {
-            var microControllerGetResponse = new MicroControllerGetResponse();
+            var microControllerGetResponse = new MicroControllerGetResponse(
+                    microController.getId(),
+                    microController.getUuid(),
+                    microController.getName(),
+                    microController.getInterval(),
+                    microController.getSdi12Address(),
+                    microController.getMacAddress(),
+                    microController.getCreatedAt(),
+                    microController.getUpdatedAt()
+            );
             microControllerGetResponse.setId(microController.getId());
             microControllerGetResponse.setUuid(microController.getUuid());
             microControllerGetResponse.setName(microController.getName());
@@ -48,17 +69,16 @@ public class MicroControllerGetResponse {
 
     public static MicroControllerGetResponse convertMicroControllerToDetailResponse(MicroController microController) {
 
-        var microControllerGetResponse = new MicroControllerGetResponse();
-        microControllerGetResponse.setId(microController.getId());
-        microControllerGetResponse.setUuid(microController.getUuid());
-        microControllerGetResponse.setName(microController.getName());
-        microControllerGetResponse.setInterval(microController.getInterval());
-        microControllerGetResponse.setSdi12Address(microController.getSdi12Address());
-        microControllerGetResponse.setMacAddress(microController.getMacAddress());
-        microControllerGetResponse.setCreatedAt(microController.getCreatedAt());
-        microControllerGetResponse.setUpdatedAt(microController.getUpdatedAt());
-
-        return microControllerGetResponse;
+        return new MicroControllerGetResponse(
+                microController.getId(),
+                microController.getUuid(),
+                microController.getName(),
+                microController.getInterval(),
+                microController.getSdi12Address(),
+                microController.getMacAddress(),
+                microController.getCreatedAt(),
+                microController.getUpdatedAt()
+        );
     }
 
 }

--- a/backend/src/main/java/com/example/stamp_app/controller/response/MicroControllerPostResponse.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/response/MicroControllerPostResponse.java
@@ -1,15 +1,40 @@
 package com.example.stamp_app.controller.response;
 
-import com.example.stamp_app.entity.MicroController;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
 
 @Data
+@Schema(description = "マイコンデータ")
 @AllArgsConstructor
 public class MicroControllerPostResponse {
 
-    HttpStatus status;
+    @Schema(description = "マイコンID", example = "1")
+    private Long id;
 
-    MicroController microController;
+    @Schema(description = "マイコンUUID", example = "61d5f7a7-7629-496e-be68-cfe022264578")
+    private String uuid;
+
+    @Schema(description = "マイコン名", example = "サンプル端末")
+    private String name;
+
+    @Schema(description = "MACアドレス", example = "AA:AA:AA:AA:AA:AA")
+    private String macAddress;
+
+    @Schema(description = "測定間隔", example = "60")
+    private String interval;
+
+    @Schema(description = "SDI-12アドレス", example = "1,3")
+    private String sdi12Address;
+
+    @Schema(description = "作成日時", example = "2023-01-01T01:01:01.111111")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "更新日時", example = "2023-01-01T01:01:01.111111")
+    private LocalDateTime updatedAt;
+
+    @Schema(description = "削除日時", example = "2023-01-01T01:01:01.111111")
+    private LocalDateTime deletedAt;
 }

--- a/backend/src/main/java/com/example/stamp_app/controller/response/measuredDataGetResponse/EnvironmentalDataGetResponse.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/response/measuredDataGetResponse/EnvironmentalDataGetResponse.java
@@ -1,33 +1,46 @@
 package com.example.stamp_app.controller.response.measuredDataGetResponse;
 
 import com.example.stamp_app.entity.EnvironmentalData;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 
 @Data
+@Schema(description = "環境データ")
 public class EnvironmentalDataGetResponse {
 
+    @Schema(description = "測定データマスターID", example = "1")
     private Long measuredDataMasterId;
 
+    @Schema(description = "DOY", example = "111.11")
     private String dayOfYear;
 
+    @Schema(description = "大気圧", example = "1011.11")
     private String airPress;
 
+    @Schema(description = "気温", example = "11.11")
     private String temp;
 
+    @Schema(description = "相対湿度", example = "77.77")
     private String humi;
 
+    @Schema(description = "二酸化炭素濃度", example = "1111.11")
     private String co2Concent;
 
+    @Schema(description = "総揮発性有機化合物", example = "11.11")
     private String tvoc;
 
+    @Schema(description = "アナログ値", example = "11.11")
     private String analogValue;
 
+    @Schema(description = "作成日時", example = "2023-01-01T01:01:01.111111")
     private LocalDateTime createdAt;
 
+    @Schema(description = "更新日時", example = "2023-01-01T01:01:01.111111")
     private LocalDateTime updatedAt;
 
+    @Schema(description = "削除日時", example = "2023-01-01T01:01:01.111111")
     private LocalDateTime deletedAt;
 
     public static EnvironmentalDataGetResponse convertFromEnvironmentalData(EnvironmentalData environmentalData, Long measuredDataMasterId, String dayOfYear) {

--- a/backend/src/main/java/com/example/stamp_app/controller/response/measuredDataGetResponse/MeasuredDataGetResponse.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/response/measuredDataGetResponse/MeasuredDataGetResponse.java
@@ -1,16 +1,21 @@
 package com.example.stamp_app.controller.response.measuredDataGetResponse;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
+@Schema(description = "測定結果取得レスポンス")
 public class MeasuredDataGetResponse {
 
+    @Schema(description = "SDI-12データリスト")
     private List<Sdi12DataGetResponse> sdi12Data;
 
+    @Schema(description = "環境データリスト")
     private List<EnvironmentalDataGetResponse> environmentalData;
 
+    @Schema(description = "電圧データ")
     private List<VoltageDataGetResponse> voltageData;
 
 }

--- a/backend/src/main/java/com/example/stamp_app/controller/response/measuredDataGetResponse/Sdi12DataGetResponse.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/response/measuredDataGetResponse/Sdi12DataGetResponse.java
@@ -1,16 +1,20 @@
 package com.example.stamp_app.controller.response.measuredDataGetResponse;
 
 import com.example.stamp_app.entity.Sdi12Data;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
+@Schema(description = "SDI-12データ")
 public class Sdi12DataGetResponse {
 
+    @Schema(description = "SDI-12アドレス", example = "1")
     private String sdiAddress;
 
+    @Schema(description = "SDI-12測定データとDOYリスト")
     private List<Sdi12DataAndDoy> dataList;
 
     public static Sdi12DataAndDoy convertFromSdi12Data(Sdi12Data sdi12Data, Long measuredDataMasterId, String dayOfYear) {
@@ -32,32 +36,46 @@ public class Sdi12DataGetResponse {
     }
 
     @Data
+    @Schema(description = "SDI-12測定データとDOY")
     public static class Sdi12DataAndDoy {
 
+        @Schema(description = "測定データマスターID", example = "1")
         private Long measuredDataMasterId;
 
+        @Schema(description = "DOY", example = "111.11")
         private String dayOfYear;
 
+        @Schema(description = "体積含水率", example = "11.11")
         private String vwc;
 
+        @Schema(description = "地温", example = "11.11")
         private String soilTemp;
 
+        @Schema(description = "比誘電率", example = "11.11")
         private String brp;
 
+        @Schema(description = "電気伝導度", example = "11.11")
         private String sbec;
 
+        @Schema(description = "間隙水電気伝導度", example = "11.11")
         private String spwec;
 
+        @Schema(description = "重力加速度(X)", example = "1.11")
         private String gax;
 
+        @Schema(description = "重力加速度(Y)", example = "1.11")
         private String gay;
 
+        @Schema(description = "重力加速度(Z)", example = "1.11")
         private String gaz;
 
+        @Schema(description = "作成日時", example = "2023-01-01T01:01:01.111111")
         private LocalDateTime createdAt;
 
+        @Schema(description = "更新日時", example = "2023-01-01T01:01:01.111111")
         private LocalDateTime updatedAt;
 
+        @Schema(description = "削除日時", example = "2023-01-01T01:01:01.111111")
         private LocalDateTime deletedAt;
 
     }

--- a/backend/src/main/java/com/example/stamp_app/controller/response/measuredDataGetResponse/VoltageDataGetResponse.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/response/measuredDataGetResponse/VoltageDataGetResponse.java
@@ -1,6 +1,7 @@
 package com.example.stamp_app.controller.response.measuredDataGetResponse;
 
 import com.example.stamp_app.entity.MeasuredDataMaster;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -8,16 +9,22 @@ import java.time.LocalDateTime;
 @Data
 public class VoltageDataGetResponse {
 
+    @Schema(description = "測定データマスターID", example = "1")
     private Long measuredDataMasterId;
 
+    @Schema(description = "DOY", example = "111.11")
     private String dayOfYear;
 
+    @Schema(description = "電圧", example = "11.11")
     private String voltage;
 
+    @Schema(description = "作成日時", example = "2023-01-01T01:01:01.111111")
     private LocalDateTime createdAt;
 
+    @Schema(description = "更新日時", example = "2023-01-01T01:01:01.111111")
     private LocalDateTime updatedAt;
 
+    @Schema(description = "削除日時", example = "2023-01-01T01:01:01.111111")
     private LocalDateTime deletedAt;
 
     public static VoltageDataGetResponse convertFromMeasuredDataMaster(MeasuredDataMaster measuredDataMaster) {

--- a/backend/src/main/java/com/example/stamp_app/service/MicroControllerService.java
+++ b/backend/src/main/java/com/example/stamp_app/service/MicroControllerService.java
@@ -71,7 +71,7 @@ public class MicroControllerService {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
-        return new MicroControllerPostResponse(HttpStatus.OK, microController);
+        return new MicroControllerPostResponse(microController.getId(), microController.getUuid(), microController.getName(), microController.getMacAddress(), microController.getInterval(), microController.getSdi12Address(), microController.getCreatedAt(), microController.getUpdatedAt(), microController.getDeletedAt());
 
     }
 

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -15,4 +15,10 @@ spring.redis.database=0
 spring.session.store-type=none
 
 # Show JPA query
-#spring.jpa.show-sql=false
+spring.jpa.show-sql=false
+
+# springdoc(Access localhost:8082/api-docs.yaml to download generated yaml file)
+springdoc.api-docs.enabled=true
+springdoc.api-docs.path=/api-docs
+# springdoc(Access localhost:8082/swagger-ui/index/html to show swagger view)
+springdoc.swagger-ui.enabled=true

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -16,4 +16,8 @@ spring.redis.database=0
 spring.session.store-type=none
 
 # Show JPA query
-#spring.jpa.show-sql=false
+spring.jpa.show-sql=false
+
+# springdoc
+springdoc.api-docs.enabled=false
+springdoc.swagger-ui.enabled=false

--- a/backend/src/test/java/com/example/stamp_app/controller/microController/MicroControllerPostTest.java
+++ b/backend/src/test/java/com/example/stamp_app/controller/microController/MicroControllerPostTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -57,7 +56,17 @@ public class MicroControllerPostTest {
 
     private MicroControllerPostResponse generateMicroControllerResponse() {
         var microController = new MicroController(1L, DummyData.VALID_UUID, "モック", "AA:AA:AA:AA:AA:AA", "30", "1,3", LocalDateTime.now(), LocalDateTime.now(), null, null, null);
-        return new MicroControllerPostResponse(HttpStatus.OK, microController);
+        return new MicroControllerPostResponse(
+                microController.getId(),
+                microController.getUuid(),
+                microController.getName(),
+                microController.getMacAddress(),
+                microController.getInterval(),
+                microController.getSdi12Address(),
+                microController.getCreatedAt(),
+                microController.getUpdatedAt(),
+                microController.getDeletedAt()
+        );
     }
 
     @BeforeEach

--- a/document/API仕様/api-docs.yaml
+++ b/document/API仕様/api-docs.yaml
@@ -1,0 +1,753 @@
+openapi: 3.0.1
+info:
+  title: Stamp IoT API仕様書
+  description: Stamp IoT用バックエンドアプリ
+  version: v1
+servers:
+- url: http://localhost:8080
+  description: ローカル環境
+- url: https://www.ems-engineering.jp
+  description: 本番環境
+tags:
+- name: Account
+  description: アカウント関連API
+- name: MeasuredData
+  description: 測定結果関連API
+- name: MicroController
+  description: マイコン関連API
+- name: Session
+  description: セッション関連API
+paths:
+  /ems/session:
+    post:
+      tags:
+      - Session
+      summary: セッション確認API
+      operationId: checkSession
+      responses:
+        "200":
+          description: 取得成功
+          content:
+            '*/*':
+              examples:
+                セッション有効:
+                  description: セッション有効
+                  value: success
+                セッション無効:
+                  description: セッション無効
+                  value: failed
+  /ems/micro-controller:
+    post:
+      tags:
+      - MicroController
+      summary: マイコン登録API
+      operationId: addMicroControllerRelation
+      requestBody:
+        description: マイコン登録パラメータ
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MicroControllerPostParam'
+        required: true
+      responses:
+        "200":
+          description: 登録成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MicroControllerPostResponse'
+        "400":
+          description: バリデーションエラー/無効なマイコン
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "401":
+          description: 認証エラー
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+  /ems/measured-data:
+    get:
+      tags:
+      - MeasuredData
+      summary: 測定データ取得API
+      operationId: getMeasuredData
+      parameters:
+      - name: microControllerUuid
+        in: query
+        description: マイコンUUID
+        required: true
+        schema:
+          pattern: "^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$"
+          type: string
+        example: 61d5f7a7-7629-496e-be68-cfe022264578
+      responses:
+        "400":
+          description: バリデーションエラー
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "200":
+          description: 取得成功
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/MeasuredDataGetResponse'
+        "403":
+          description: マイコン所有者不一致エラー
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+    post:
+      tags:
+      - MeasuredData
+      summary: 測定データ登録API
+      operationId: addMeasuredData
+      requestBody:
+        description: 登録情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MeasuredDataPostParam'
+        required: true
+      responses:
+        "400":
+          description: バリデーションエラー
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "403":
+          description: 無効なマイコン
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "200":
+          description: 登録成功
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "401":
+          description: 認証エラー
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+  /ems/account/register:
+    post:
+      tags:
+      - Account
+      summary: アカウント登録API
+      operationId: addAccount
+      requestBody:
+        description: 登録情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterPostParam'
+        required: true
+      responses:
+        "400":
+          description: バリデーションエラー
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "200":
+          description: 登録成功
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+  /ems/account/logout:
+    post:
+      tags:
+      - Account
+      summary: ログアウトAPI
+      operationId: logout
+      responses:
+        "200":
+          description: ログアウト成功
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+  /ems/account/login:
+    post:
+      tags:
+      - Account
+      summary: ログインAPI
+      operationId: login
+      requestBody:
+        description: ログイン情報
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginPostParam'
+        required: true
+      responses:
+        "400":
+          description: バリデーションエラー
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "401":
+          description: 認証エラー
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "200":
+          description: ログイン成功
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+  /ems/micro-controller/detail:
+    get:
+      tags:
+      - MicroController
+      summary: マイコン詳細取得API
+      operationId: getMicroControllerDetail
+      parameters:
+      - name: microControllerUuid
+        in: query
+        description: マイコンUUID
+        required: true
+        schema:
+          pattern: "^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$"
+          type: string
+        example: 61d5f7a7-7629-496e-be68-cfe022264578
+      responses:
+        "400":
+          description: 無効なアカウント
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "200":
+          description: 取得成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MicroControllerGetResponse'
+    patch:
+      tags:
+      - MicroController
+      summary: マイコン詳細更新API
+      operationId: updateMicroControllerDetail
+      requestBody:
+        description: マイコン詳細更新パラメータ
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MicroControllerPatchParam'
+        required: true
+      responses:
+        "400":
+          description: 無効なアカウント
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "200":
+          description: 取得成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MicroControllerGetResponse'
+  /ems/micro-controller/info:
+    get:
+      tags:
+      - MicroController
+      summary: マイコン一覧取得API
+      operationId: getMicroControllerInfo
+      responses:
+        "400":
+          description: 無効なアカウント
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "200":
+          description: 取得成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MicroControllerGetResponse'
+  /ems/account/info:
+    get:
+      tags:
+      - Account
+      summary: アカウント詳細取得API
+      operationId: accountInfo
+      responses:
+        "400":
+          description: バリデーションエラー
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "200":
+          description: ログイン成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountGetResponse'
+components:
+  schemas:
+    MicroControllerPostParam:
+      required:
+      - macAddress
+      - userId
+      type: object
+      properties:
+        userId:
+          type: integer
+          description: ユーザーID
+          format: int64
+        macAddress:
+          pattern: "^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$"
+          type: string
+          description: MACアドレス
+      description: マイコン登録パラメータ
+    MicroControllerPostResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: マイコンID
+          format: int64
+          example: 1
+        uuid:
+          type: string
+          description: マイコンUUID
+          example: 61d5f7a7-7629-496e-be68-cfe022264578
+        name:
+          type: string
+          description: マイコン名
+          example: サンプル端末
+        macAddress:
+          type: string
+          description: MACアドレス
+          example: AA:AA:AA:AA:AA:AA
+        interval:
+          type: string
+          description: 測定間隔
+          example: "60"
+        sdi12Address:
+          type: string
+          description: SDI-12アドレス
+          example: "1,3"
+        createdAt:
+          type: string
+          description: 作成日時
+          format: date-time
+        updatedAt:
+          type: string
+          description: 更新日時
+          format: date-time
+        deletedAt:
+          type: string
+          description: 削除日時
+          format: date-time
+      description: マイコンデータ
+    "Null":
+      type: object
+    EnvironmentalDataParam:
+      type: object
+      properties:
+        airPress:
+          type: string
+          description: 大気圧
+          example: "1011.11"
+        temp:
+          type: string
+          description: 気温
+          example: "11.11"
+        humi:
+          type: string
+          description: 相対湿度
+          example: "77.77"
+        co2Concent:
+          type: string
+          description: 二酸化炭素濃度
+          example: "1111.11"
+        tvoc:
+          type: string
+          description: 総揮発性有機化合物
+          example: "11.11"
+        analogValue:
+          type: string
+          description: アナログ値
+          example: "11.11"
+      description: 環境データパラメータ
+    MeasuredDataPostParam:
+      required:
+      - macAddress
+      type: object
+      properties:
+        macAddress:
+          pattern: "^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$"
+          type: string
+          description: MACアドレス
+          example: AA:AA:AA:AA:AA:AA
+        sdi12Param:
+          type: array
+          description: SDI-12パラメータリスト
+          items:
+            $ref: '#/components/schemas/Sdi12Param'
+        environmentalDataParam:
+          type: array
+          description: 環境データパラメータリスト
+          items:
+            $ref: '#/components/schemas/EnvironmentalDataParam'
+        voltage:
+          type: string
+          description: 電圧
+          example: "11.11"
+      description: 測定結果登録パラメータ
+    Sdi12Param:
+      required:
+      - sdiAddress
+      type: object
+      properties:
+        sensorId:
+          type: integer
+          description: センサID
+          format: int64
+          example: 1
+        sdiAddress:
+          type: string
+          description: SDI-12アドレス
+          example: "1"
+        vwc:
+          type: string
+          description: 体積含水率
+          example: "11.11"
+        soilTemp:
+          type: string
+          description: 地温
+          example: "11.11"
+        brp:
+          type: string
+          description: 比誘電率
+          example: "11.11"
+        sbec:
+          type: string
+          description: 電気伝導度
+          example: "11.11"
+        spwec:
+          type: string
+          description: 間隙水電気伝導度
+          example: "11.11"
+        gax:
+          type: string
+          description: 重力加速度(X)
+          example: "1.11"
+        gay:
+          type: string
+          description: 重力加速度(Y)
+          example: "1.11"
+        gaz:
+          type: string
+          description: 重力加速度(Z)
+          example: "1.11"
+      description: SDI-12パラメータ
+    RegisterPostParam:
+      required:
+      - email
+      - password
+      type: object
+      properties:
+        email:
+          pattern: "^([a-zA-Z0-9])+([a-zA-Z0-9._-])*@([a-zA-Z0-9_-])+([a-zA-Z0-9._-]+)+$"
+          type: string
+          description: メールアドレス
+          example: aaa@example.com
+        password:
+          pattern: "^(?=.*[A-Z])[a-zA-Z0-9.?/-]{8,24}$"
+          type: string
+          description: パスワード
+          example: SamplePassword
+      description: アカウント登録パラメータ
+    LoginPostParam:
+      required:
+      - email
+      - password
+      type: object
+      properties:
+        email:
+          pattern: "^([a-zA-Z0-9])+([a-zA-Z0-9._-])*@([a-zA-Z0-9_-])+([a-zA-Z0-9._-]+)+$"
+          type: string
+          description: メールアドレス
+          example: aaa@example.com
+        password:
+          type: string
+          description: パスワード
+          example: SamplePassword
+      description: ログインパラメータ
+    MicroControllerPatchParam:
+      required:
+      - interval
+      - microControllerUuid
+      type: object
+      properties:
+        microControllerUuid:
+          pattern: "^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$"
+          type: string
+          description: マイコンUUID
+          example: 61d5f7a7-7629-496e-be68-cfe022264578
+        name:
+          type: string
+          description: マイコン名
+          example: サンプル端末
+        interval:
+          pattern: ^(60|30|20|15|10|5|1)$
+          type: string
+          description: 測定間隔
+          example: "60"
+        sdi12Address:
+          pattern: "^(([0-9A-Za-z]{1},)*[0-9A-za-z]{1})|([0-9A-za-z]{1})$"
+          type: string
+          description: SDI-12アドレス
+          example: "1,3"
+      description: マイコン更新データ
+    MicroControllerGetResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: マイコンID
+          format: int64
+          example: 1
+        uuid:
+          type: string
+          description: マイコンUUID
+          example: 61d5f7a7-7629-496e-be68-cfe022264578
+        name:
+          type: string
+          description: マイコン名
+          example: サンプル端末
+        macAddress:
+          type: string
+          description: MACアドレス
+          example: AA:AA:AA:AA:AA:AA
+        interval:
+          type: string
+          description: 測定間隔
+          example: "60"
+        sdi12Address:
+          type: string
+          description: SDI-12アドレス
+          example: "1,3"
+        createdAt:
+          type: string
+          description: 作成日時
+          format: date-time
+        updatedAt:
+          type: string
+          description: 更新日時
+          format: date-time
+      description: マイコン詳細データ
+    EnvironmentalDataGetResponse:
+      type: object
+      properties:
+        measuredDataMasterId:
+          type: integer
+          description: 測定データマスターID
+          format: int64
+          example: 1
+        dayOfYear:
+          type: string
+          description: DOY
+          example: "111.11"
+        airPress:
+          type: string
+          description: 大気圧
+          example: "1011.11"
+        temp:
+          type: string
+          description: 気温
+          example: "11.11"
+        humi:
+          type: string
+          description: 相対湿度
+          example: "77.77"
+        co2Concent:
+          type: string
+          description: 二酸化炭素濃度
+          example: "1111.11"
+        tvoc:
+          type: string
+          description: 総揮発性有機化合物
+          example: "11.11"
+        analogValue:
+          type: string
+          description: アナログ値
+          example: "11.11"
+        createdAt:
+          type: string
+          description: 作成日時
+          format: date-time
+        updatedAt:
+          type: string
+          description: 更新日時
+          format: date-time
+        deletedAt:
+          type: string
+          description: 削除日時
+          format: date-time
+      description: 環境データ
+    MeasuredDataGetResponse:
+      type: object
+      properties:
+        sdi12Data:
+          type: array
+          description: SDI-12データリスト
+          items:
+            $ref: '#/components/schemas/Sdi12DataGetResponse'
+        environmentalData:
+          type: array
+          description: 環境データリスト
+          items:
+            $ref: '#/components/schemas/EnvironmentalDataGetResponse'
+        voltageData:
+          type: array
+          description: 電圧データ
+          items:
+            $ref: '#/components/schemas/VoltageDataGetResponse'
+      description: 測定結果取得レスポンス
+    Sdi12DataAndDoy:
+      type: object
+      properties:
+        measuredDataMasterId:
+          type: integer
+          description: 測定データマスターID
+          format: int64
+          example: 1
+        dayOfYear:
+          type: string
+          description: DOY
+          example: "111.11"
+        vwc:
+          type: string
+          description: 体積含水率
+          example: "11.11"
+        soilTemp:
+          type: string
+          description: 地温
+          example: "11.11"
+        brp:
+          type: string
+          description: 比誘電率
+          example: "11.11"
+        sbec:
+          type: string
+          description: 電気伝導度
+          example: "11.11"
+        spwec:
+          type: string
+          description: 間隙水電気伝導度
+          example: "11.11"
+        gax:
+          type: string
+          description: 重力加速度(X)
+          example: "1.11"
+        gay:
+          type: string
+          description: 重力加速度(Y)
+          example: "1.11"
+        gaz:
+          type: string
+          description: 重力加速度(Z)
+          example: "1.11"
+        createdAt:
+          type: string
+          description: 作成日時
+          format: date-time
+        updatedAt:
+          type: string
+          description: 更新日時
+          format: date-time
+        deletedAt:
+          type: string
+          description: 削除日時
+          format: date-time
+      description: SDI-12測定データとDOY
+    Sdi12DataGetResponse:
+      type: object
+      properties:
+        sdiAddress:
+          type: string
+          description: SDI-12アドレス
+          example: "1"
+        dataList:
+          type: array
+          description: SDI-12測定データとDOYリスト
+          items:
+            $ref: '#/components/schemas/Sdi12DataAndDoy'
+      description: SDI-12データ
+    VoltageDataGetResponse:
+      type: object
+      properties:
+        measuredDataMasterId:
+          type: integer
+          description: 測定データマスターID
+          format: int64
+          example: 1
+        dayOfYear:
+          type: string
+          description: DOY
+          example: "111.11"
+        voltage:
+          type: string
+          description: 電圧
+          example: "11.11"
+        createdAt:
+          type: string
+          description: 作成日時
+          format: date-time
+        updatedAt:
+          type: string
+          description: 更新日時
+          format: date-time
+        deletedAt:
+          type: string
+          description: 削除日時
+          format: date-time
+      description: 電圧データ
+    AccountGetResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: アカウントID
+          format: int64
+          example: 1
+        name:
+          type: string
+          description: 登録名
+          example: サンプル太郎
+        createdAt:
+          type: string
+          description: 作成日時
+          format: date-time
+        updatedAt:
+          type: string
+          description: 更新日時
+          format: date-time
+      description: アカウント情報


### PR DESCRIPTION
## 実装内容

- OpenAPIのAPI仕様書を追加
  - springdocを使用して生成

## 確認手順

- バックエンドを起動後，`localhost:8082/api-docs.yaml` にアクセスし，yamlファイルがダウンロードできること
- バックエンドを起動後， `http://localhost:8082/swagger-ui/index.html` にアクセスし，ブラウザ上で仕様書が確認できること

## スクリーンショット

- UI表示確認 
<img width="1680" alt="スクリーンショット 2023-07-16 15 49 12" src="https://github.com/mktkhr/stamp-iot/assets/51685340/2ddea3b9-1b22-4268-9aa6-076217b5faab">

## 確認した環境

- M1 MacBook Pro
- macOS Monterey version 13.3.1
- Arduino IDE version 1.8.16

resolve #87 