### PR TITLE
ログイン時のアラートの挙動を修正する

### DIFF
--- a/frontend/src/views/login/composable.ts
+++ b/frontend/src/views/login/composable.ts
@@ -61,13 +61,7 @@ export const useLogin = () => {
     await accountStore
       .login(mailAddressRef.value, passwordRef.value)
       .then(() => {
-        notificationMessage.value = 'ログインに成功しました。';
-        notificationType.value = NotificationType.SUCCESS;
-        showNotification.value = true;
-        setTimeout(() => {
-          showNotification.value = false;
-          router.replace('/home');
-        }, 1500);
+        router.replace('/home');
       })
       .catch((e) => {
         const statusCode = e.response.status.toString();


### PR DESCRIPTION
## 実装内容

- ログイン成功時のアラートを表示しないように修正

## 確認手順

- アカウントを作成する
- ログインする
- 

## スクリーンショット

- アカウント情報が誤っていた場合はアラートが表示され，ログイン成功時にはアラートが表示されないこと

https://github.com/mktkhr/stamp-iot/assets/51685340/bf90ca61-8889-4bb1-abb1-22e39c3074dc

## 確認した環境

- M1 MacBook Pro
- macOS Ventura version 13.4
- Arduino IDE version 1.8.16

resolve #94