### PR TITLE
マイコン詳細画面のmacアドレスが正常に表示されていない

### DIFF
--- a/backend/src/main/java/com/example/stamp_app/controller/response/MicroControllerGetResponse.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/response/MicroControllerGetResponse.java
@@ -47,20 +47,12 @@ public class MicroControllerGetResponse {
                     microController.getId(),
                     microController.getUuid(),
                     microController.getName(),
+                    microController.getMacAddress(),
                     microController.getInterval(),
                     microController.getSdi12Address(),
-                    microController.getMacAddress(),
                     microController.getCreatedAt(),
                     microController.getUpdatedAt()
             );
-            microControllerGetResponse.setId(microController.getId());
-            microControllerGetResponse.setUuid(microController.getUuid());
-            microControllerGetResponse.setName(microController.getName());
-            microControllerGetResponse.setInterval(microController.getInterval());
-            microControllerGetResponse.setSdi12Address(microController.getSdi12Address());
-            microControllerGetResponse.setMacAddress(microController.getMacAddress());
-            microControllerGetResponse.setCreatedAt(microController.getCreatedAt());
-            microControllerGetResponse.setUpdatedAt(microController.getUpdatedAt());
             microControllerGetResponseList.add(microControllerGetResponse);
         });
 
@@ -73,9 +65,9 @@ public class MicroControllerGetResponse {
                 microController.getId(),
                 microController.getUuid(),
                 microController.getName(),
+                microController.getMacAddress(),
                 microController.getInterval(),
                 microController.getSdi12Address(),
-                microController.getMacAddress(),
                 microController.getCreatedAt(),
                 microController.getUpdatedAt()
         );


### PR DESCRIPTION
## 実装内容

- マイコン詳細画面のレスポンス生成時に誤りがあったため，修正

## 確認手順

- マイコン詳細画面にアクセスし，表示を確認する

## スクリーンショット

- マイコン詳細画面でmacアドレスが正常に表示されていること

https://github.com/mktkhr/stamp-iot/assets/51685340/2f5aafc7-819e-45e4-bec3-af1bc0d41d25

## 確認した環境

- M1 MacBook Pro
- macOS Ventura version 13.4
- Arduino IDE version 1.8.16

resolve #96