### PR TITLE
マイコン側でマイコンの設定値を取得する

### DIFF
--- a/MainCode/MainCode.ino
+++ b/MainCode/MainCode.ino
@@ -1044,7 +1044,7 @@ void postRequest(String host, String uri, String measureData)
 /**
  * @brief Preferenceに設定値を書き込む
  *
- * @param target 書き込み先(0: 起動モード, 1: ssid, 2: pass, 3: host)
+ * @param target 書き込み先(0: 起動モード, 1: ssid, 2: pass, 3: host, 4: 測定間隔, 5: 測定アドレス)
  * @param value 書き込み値
  */
 void writePreference(int target, String value)
@@ -1069,6 +1069,14 @@ void writePreference(int target, String value)
     preferences.putString("host", value);
     preferences.end();
     break;
+  case 4:
+    preferences.putString("interval", value);
+    preferences.end();
+    break;
+  case 5:
+    preferences.putString("address", value);
+    preferences.end();
+    break;
   default:
     break;
   }
@@ -1077,7 +1085,7 @@ void writePreference(int target, String value)
 /**
  * @brief Preferenceに書き込まれた設定値の読み取り
  *
- * @param target 読み取り先(0: 起動モード, 1: ssid, 2: pass, 3: host)
+ * @param target 読み取り先(0: 起動モード, 1: ssid, 2: pass, 3: host, 4: 測定間隔, 5: 測定アドレス)
  */
 String readPreference(int target)
 {
@@ -1100,6 +1108,14 @@ String readPreference(int target)
     return value;
   case 3:
     value = preferences.getString("host", "未設定");
+    preferences.end();
+    return value;
+  case 4:
+    value = preferences.getString("interval", "60");
+    preferences.end();
+    return value;
+  case 5:
+    value = preferences.getString("address", "");
     preferences.end();
     return value;
   default:

--- a/MainCode/MainCode.ino
+++ b/MainCode/MainCode.ino
@@ -1042,6 +1042,204 @@ void postRequest(String host, String uri, String measureData)
 }
 
 /**
+ * @brief Getリクエストを送信
+ *
+ */
+void getRequest()
+{
+  Serial.println("\r\n-----Connecting to HOST-----\r\n");
+  String targetHost;
+  int targetPort;
+  WiFiClientSecure sslClient;
+  WiFiClient client;
+  // ArduinoJson
+  const int BUFFER_SIZE = JSON_OBJECT_SIZE(4) + JSON_ARRAY_SIZE(1);
+  StaticJsonDocument<BUFFER_SIZE> jsonBuffer;
+
+  const String bootMode = readPreference(0);
+  if (bootMode == String(NORMAL_MODE))
+  {
+    targetHost = emsHost;
+    targetPort = productionPort;
+    sslClient.setInsecure();
+    sslClient.setCACert(PUBLIC_KEY);
+  }
+  else
+  {
+    targetHost = readPreference(3);
+    targetPort = localPort;
+  }
+
+  Serial.print("TargetHost: ");
+  Serial.println(targetHost);
+  Serial.print("TargetPort: ");
+  Serial.println(targetPort);
+
+  // ホスト名(String)をchar*に変換
+  int length = targetHost.length() + 1;
+  char bufferArray[length];
+  targetHost.toCharArray(bufferArray, length);
+  const char *hostCharPointer = bufferArray;
+
+  const int requestLimit = 5;
+
+  for (int j = 0; j < requestLimit; j++)
+  {
+    if (bootMode == String(NORMAL_MODE))
+    {
+      if (sslClient.connect(hostCharPointer, targetPort))
+      {
+        // HTTPSの場合
+        Serial.println("\r\n-----Get measuring settings-----\r\n");
+        sslClient.println("GET " + getMicroControllerUri + "?macAddress=" + WiFi.macAddress() + " HTTP/1.1");
+        sslClient.println("Host: " + targetHost + ":" + String(targetPort));
+        sslClient.println("Connection: close");
+        sslClient.println("Content-Type: application/json");
+        sslClient.print("Content-Length: 0");
+        sslClient.println();
+        sslClient.println();
+        delay(100);
+
+        // ヘッダーの読み飛ばし
+        String response;
+        while (sslClient.available())
+        {
+          response = sslClient.readStringUntil('\r');
+          response.trim();
+          if (response.length() == 0)
+          {
+            break;
+          }
+        }
+        delay(100);
+
+        // レスポンスボディを取得
+        String responseBuffer;
+        while (sslClient.available())
+        {
+          response = sslClient.readStringUntil('\r');
+          response.trim();
+          responseBuffer.concat(response);
+        }
+
+        // JSONパース
+        char json[responseBuffer.length() + 1];
+        responseBuffer.toCharArray(json, sizeof(json));
+        Serial.println(json);
+        auto error = deserializeJson(jsonBuffer, json);
+        delay(200);
+        if (error)
+        {
+          Serial.print("JSON parse error: ");
+          Serial.println(error.c_str());
+          return;
+        }
+        const char *interval = jsonBuffer["interval"];
+        Serial.println(interval);
+        const char *sdi12Address = jsonBuffer["sdi12Address"];
+        Serial.println(sdi12Address);
+
+        String intervalString = String(interval);
+        String sdi12AddressString = String(sdi12Address);
+        if (intervalString == "1" || intervalString == "5" || intervalString == "10" || intervalString == "15" || intervalString == "20" || intervalString == "30" || intervalString == "60")
+        {
+          writePreference(4, intervalString);
+        }
+
+        writePreference(5, sdi12AddressString);
+
+        Serial.println("closing connection");
+
+        delay(100);
+        sslClient.stop();
+        return;
+      }
+      else
+      {
+        Serial.println(".");
+        delay(200);
+      }
+    }
+    else
+    {
+      // HTTPの場合
+      if (client.connect(hostCharPointer, targetPort))
+      {
+        Serial.println("\r\n-----Get measuring settings-----\r\n");
+        client.println("GET " + getMicroControllerUri + "?macAddress=" + WiFi.macAddress() + " HTTP/1.1");
+        client.println("Host: " + targetHost + ":" + String(targetPort));
+        client.println("Connection: close");
+        client.println("Content-Type: application/json");
+        client.print("Content-Length: 0");
+        client.println();
+        client.println();
+        delay(100);
+
+        // ヘッダーの読み飛ばし
+        String response;
+        while (client.available())
+        {
+          response = client.readStringUntil('\r');
+          Serial.print(response);
+          response.trim();
+          if (response.length() == 0)
+          {
+            break;
+          }
+        }
+        delay(100);
+
+        // レスポンスボディを取得
+        String responseBuffer;
+        while (client.available())
+        {
+          response = client.readStringUntil('\r');
+          response.trim();
+          responseBuffer.concat(response);
+        }
+
+        // JSONパース
+        char json[responseBuffer.length() + 1];
+        responseBuffer.toCharArray(json, sizeof(json));
+        Serial.println(json);
+        auto error = deserializeJson(jsonBuffer, json);
+        delay(200);
+        if (error && responseBuffer.length() == 0)
+        {
+          Serial.print("JSON parse error: ");
+          Serial.println(error.c_str());
+          return;
+        }
+        const char *interval = jsonBuffer["interval"];
+        Serial.println(interval);
+        const char *sdi12Address = jsonBuffer["sdi12Address"];
+        Serial.println(sdi12Address);
+
+        String intervalString = String(interval);
+        String sdi12AddressString = String(sdi12Address);
+        if (intervalString == "1" || intervalString == "5" || intervalString == "10" || intervalString == "15" || intervalString == "20" || intervalString == "30" || intervalString == "60")
+        {
+          writePreference(4, intervalString);
+        }
+
+        writePreference(5, sdi12AddressString);
+
+        Serial.println("closing connection");
+        delay(100);
+        client.stop();
+        return;
+      }
+      else
+      {
+        Serial.println(".");
+        delay(200);
+      }
+    }
+  }
+  Serial.println("\r\n-----GET request failed.-----\r\n");
+}
+
+/**
  * @brief Preferenceに設定値を書き込む
  *
  * @param target 書き込み先(0: 起動モード, 1: ssid, 2: pass, 3: host, 4: 測定間隔, 5: 測定アドレス)

--- a/backend/src/main/java/com/example/stamp_app/config/AppInterceptor.java
+++ b/backend/src/main/java/com/example/stamp_app/config/AppInterceptor.java
@@ -50,6 +50,10 @@ public class AppInterceptor implements HandlerInterceptor {
             return true;
         }
 
+        if (path.contains("/micro-controller/detail/no-session") && Objects.equals(request.getMethod(), HttpMethod.GET.name())) {
+            return true;
+        }
+
         var cookieList = request.getCookies();
 
         var sessionUuid = sessionService.getSessionUuidFromCookie(cookieList);

--- a/backend/src/main/java/com/example/stamp_app/controller/MicroControllerController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/MicroControllerController.java
@@ -4,6 +4,7 @@ import com.example.stamp_app.controller.param.MicroControllerPostParam;
 import com.example.stamp_app.controller.param.microController.MicroControllerPatchParam;
 import com.example.stamp_app.controller.response.MicroControllerGetResponse;
 import com.example.stamp_app.controller.response.MicroControllerPostResponse;
+import com.example.stamp_app.controller.response.microController.MicroControllerGetDetailNoSessionResponse;
 import com.example.stamp_app.entity.RequestedUser;
 import com.example.stamp_app.service.MicroControllerService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -83,7 +84,7 @@ public class MicroControllerController {
      */
     @Operation(summary = "マイコン詳細取得API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "取得成功", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, array = @ArraySchema(schema = @Schema(implementation = MicroControllerGetResponse.class)))),
+            @ApiResponse(responseCode = "200", description = "取得成功", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MicroControllerGetResponse.class))),
             @ApiResponse(responseCode = "400", description = "無効なアカウント", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
     })
     @GetMapping(value = "/detail")
@@ -93,6 +94,27 @@ public class MicroControllerController {
             @Pattern(regexp = "^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$") String microControllerUuid) {
         var microController = microControllerService.getMicroControllerDetail(microControllerUuid);
         var response = MicroControllerGetResponse.convertMicroControllerToDetailResponse(microController);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    /**
+     * マイコン詳細情報取得(セッション無し)
+     *
+     * @param macAddress マイコンMACアドレス
+     */
+    @Operation(summary = "マイコン詳細取得API(セッション無し)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "取得成功", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MicroControllerGetDetailNoSessionResponse.class))),
+            @ApiResponse(responseCode = "400", description = "無効なリクエスト", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
+    })
+    @GetMapping(value = "/detail/no-session")
+    public ResponseEntity<MicroControllerGetDetailNoSessionResponse> getMicroControllerDetailWithoutSession(
+            @Parameter(required = true, description = "マイコンUUID", example = "AA:AA:AA:AA:AA:AA")
+            @RequestParam
+            @Pattern(regexp = "^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$") String macAddress) {
+        var microController = microControllerService.getMicroControllerDetailWithMacAddress(macAddress);
+        var response = MicroControllerGetDetailNoSessionResponse.convertMicroControllerToDetailResponse(microController);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/backend/src/main/java/com/example/stamp_app/controller/response/microController/MicroControllerGetDetailNoSessionResponse.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/response/microController/MicroControllerGetDetailNoSessionResponse.java
@@ -1,0 +1,26 @@
+package com.example.stamp_app.controller.response.microController;
+
+import com.example.stamp_app.entity.MicroController;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(description = "マイコン詳細データ(セッション無し)")
+@Getter
+@AllArgsConstructor
+public class MicroControllerGetDetailNoSessionResponse {
+
+    @Schema(description = "測定間隔", example = "60")
+    private String interval;
+
+    @Schema(description = "SDI-12アドレス", example = "1,3")
+    private String sdi12Address;
+
+    public static MicroControllerGetDetailNoSessionResponse convertMicroControllerToDetailResponse(MicroController microController) {
+
+        return new MicroControllerGetDetailNoSessionResponse(
+                microController.getInterval(),
+                microController.getSdi12Address()
+        );
+    }
+}

--- a/backend/src/main/java/com/example/stamp_app/service/MicroControllerService.java
+++ b/backend/src/main/java/com/example/stamp_app/service/MicroControllerService.java
@@ -116,9 +116,33 @@ public class MicroControllerService {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
-        // アカウントが存在しなかった場合，400を返す
+        // マイコンが存在しなかった場合，400を返す
         if (microController == null) {
             log.error("該当のマイクロコントローラーの取得に失敗 UUID: " + microControllerUuid);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+        }
+
+        return microController;
+    }
+
+    /**
+     * マイコン詳細を取得(MACアドレス)
+     *
+     * @param macAddress マイコンID
+     * @return マイコン詳細
+     */
+    public MicroController getMicroControllerDetailWithMacAddress(String macAddress) {
+        MicroController microController;
+
+        try {
+            microController = microControllerRepository.findByMacAddress(macAddress);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        // マイコンが存在しなかった場合，400を返す
+        if (microController == null) {
+            log.error("該当のマイクロコントローラーの取得に失敗 MACアドレス: " + macAddress);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
         }
 

--- a/backend/src/test/java/com/example/stamp_app/controller/microController/MicroControllerNoSessionGetTest.java
+++ b/backend/src/test/java/com/example/stamp_app/controller/microController/MicroControllerNoSessionGetTest.java
@@ -1,0 +1,96 @@
+package com.example.stamp_app.controller.microController;
+
+import com.example.stamp_app.config.AppInterceptor;
+import com.example.stamp_app.controller.MicroControllerController;
+import com.example.stamp_app.entity.DummyData;
+import com.example.stamp_app.entity.MicroController;
+import com.example.stamp_app.entity.RequestedUser;
+import com.example.stamp_app.service.MicroControllerService;
+import com.example.stamp_app.session.RedisService;
+import com.example.stamp_app.session.SessionService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MicroControllerController.class)
+public class MicroControllerNoSessionGetTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @MockBean
+    AppInterceptor appInterceptor;
+    @MockBean
+    RequestedUser requestedUser;
+    @MockBean
+    MicroControllerService microControllerService;
+    @MockBean
+    SessionService sessionService;
+    @MockBean
+    RedisService redisService;
+
+    private MicroController generateMicroController() {
+        return new MicroController(1L, DummyData.VALID_UUID, "モック", "AA:AA:AA:AA:AA:AA", "30", "1,3", LocalDateTime.now(), LocalDateTime.now(), null, null, null);
+    }
+
+    private ResultActions mockMvcPerform(String path) throws Exception {
+        return mockMvc.perform(MockMvcRequestBuilders.get(path)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+    }
+
+    @BeforeEach
+    void setup() {
+        when(appInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+        when(microControllerService.getMicroControllerDetailWithMacAddress(any())).thenReturn(generateMicroController());
+    }
+
+    @Nested
+    @DisplayName("マイコン詳細取得テスト")
+    class GetTest {
+
+        @Test
+        void リクエストパラメータのMACアドレスがnullの場合400を返すこと() throws Exception {
+
+            mockMvcPerform(DummyData.MICROCONTROLLER_NO_SESSION_GET_PATH).andExpect(status().isBadRequest());
+
+        }
+
+        @Test
+        void リクエストパラメータのMACアドレスが空の場合400を返すこと() throws Exception {
+
+            mockMvc.perform(MockMvcRequestBuilders.get(DummyData.MICROCONTROLLER_NO_SESSION_GET_PATH).param("macAddress", "")).andExpect(status().isBadRequest());
+
+        }
+
+        @Test
+        void リクエストパラメータのMACアドレスが不適切な値の場合400を返すこと() throws Exception {
+
+            mockMvc.perform(MockMvcRequestBuilders.get(DummyData.MICROCONTROLLER_NO_SESSION_GET_PATH).param("macAddress", DummyData.INVALID_MAC_ADDRESS)).andExpect(status().isBadRequest());
+
+        }
+
+        @Test
+        void リクエストパラメータのMACアドレスが適切な値の場合200を返すこと() throws Exception {
+
+            mockMvc.perform(MockMvcRequestBuilders.get(DummyData.MICROCONTROLLER_NO_SESSION_GET_PATH).param("macAddress", DummyData.VALID_MAC_ADDRESS)).andExpect(status().isOk());
+
+        }
+    }
+}

--- a/backend/src/test/java/com/example/stamp_app/entity/DummyData.java
+++ b/backend/src/test/java/com/example/stamp_app/entity/DummyData.java
@@ -9,6 +9,8 @@ public class DummyData {
     public static final String MICROCONTROLLER_POST_PATH = "/ems/micro-controller";
     public static final String MICROCONTROLLER_GET_PATH = "/ems/micro-controller/detail";
 
+    public static final String MICROCONTROLLER_NO_SESSION_GET_PATH = "/ems/micro-controller/detail/no-session";
+
     public static final String INVALID_7_LENGTH_PASSWORD = "A123456";
 
     public static final String VALID_8_LENGTH_PASSWORD = "A1234567";

--- a/document/API仕様/api-docs.yaml
+++ b/document/API仕様/api-docs.yaml
@@ -26,7 +26,7 @@ paths:
       operationId: checkSession
       responses:
         "200":
-          description: 取得成功
+          description: 確認成功
           content:
             '*/*':
               examples:
@@ -198,14 +198,14 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/Null'
-        "401":
-          description: 認証エラー
+        "200":
+          description: ログイン成功
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/Null'
-        "200":
-          description: ログイン成功
+        "401":
+          description: 認証エラー
           content:
             '*/*':
               schema:
@@ -226,20 +226,18 @@ paths:
           type: string
         example: 61d5f7a7-7629-496e-be68-cfe022264578
       responses:
+        "200":
+          description: 取得成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MicroControllerGetResponse'
         "400":
           description: 無効なアカウント
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/Null'
-        "200":
-          description: 取得成功
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/MicroControllerGetResponse'
     patch:
       tags:
       - MicroController
@@ -253,12 +251,6 @@ paths:
               $ref: '#/components/schemas/MicroControllerPatchParam'
         required: true
       responses:
-        "400":
-          description: 無効なアカウント
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Null'
         "200":
           description: 取得成功
           content:
@@ -267,6 +259,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/MicroControllerGetResponse'
+        "400":
+          description: 無効なアカウント
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
   /ems/micro-controller/info:
     get:
       tags:
@@ -274,12 +272,6 @@ paths:
       summary: マイコン一覧取得API
       operationId: getMicroControllerInfo
       responses:
-        "400":
-          description: 無効なアカウント
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Null'
         "200":
           description: 取得成功
           content:
@@ -288,6 +280,40 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/MicroControllerGetResponse'
+        "400":
+          description: 無効なアカウント
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+  /ems/micro-controller/detail/no-session:
+    get:
+      tags:
+      - MicroController
+      summary: マイコン詳細取得API(セッション無し)
+      operationId: getMicroControllerDetailWithoutSession
+      parameters:
+      - name: macAddress
+        in: query
+        description: マイコンUUID
+        required: true
+        schema:
+          pattern: "^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$"
+          type: string
+        example: AA:AA:AA:AA:AA:AA
+      responses:
+        "200":
+          description: 取得成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MicroControllerGetDetailNoSessionResponse'
+        "400":
+          description: 無効なリクエスト
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
   /ems/account/info:
     get:
       tags:
@@ -563,6 +589,18 @@ components:
           description: 更新日時
           format: date-time
       description: マイコン詳細データ
+    MicroControllerGetDetailNoSessionResponse:
+      type: object
+      properties:
+        interval:
+          type: string
+          description: 測定間隔
+          example: "60"
+        sdi12Address:
+          type: string
+          description: SDI-12アドレス
+          example: "1,3"
+      description: マイコン詳細データ(セッション無し)
     EnvironmentalDataGetResponse:
       type: object
       properties:


### PR DESCRIPTION
## 実装内容

- マイコンからバックエンドに設定値を取得できるように修正
    - APIを追加し，セッション無しで叩けるように実装

## 確認手順

- マイコンを起動，シリアルモニタを確認し，GETできていることを確認する

## スクリーンショット

- ローカル環境でマイコン側で設定値が取得できること(シリアルモニタ)
<img width="369" alt="スクリーンショット 2023-08-06 0 34 56" src="https://github.com/mktkhr/stamp-iot/assets/51685340/faf21c12-9676-4c35-85f5-26b4bc90f5f4">

- 本番環境でマイコン側で設定値が取得できること(シリアルモニタ)
<img width="231" alt="スクリーンショット 2023-08-06 0 58 43" src="https://github.com/mktkhr/stamp-iot/assets/51685340/c3012b60-5587-47b8-8e17-90383bf83f81">


## 確認した環境

- M1 MacBook Pro
- macOS Ventura version 13.4
- Arduino IDE version 1.8.16

resolve #98 