### PR TITLE
サーバー証明書を更新する

### DIFF
--- a/document/証明書関連/証明書更新ログ.md
+++ b/document/証明書関連/証明書更新ログ.md
@@ -1,0 +1,60 @@
+### 証明書更新ログ
+
+#### ログ
+- 実行時の状態
+  - 証明書を初回に取得した際のコンテナが `Exited (0)` の状態で残っている
+  - 証明書の期限内(2023-08-12期限で2023-08-06に実行)
+
+- SSHでサーバー内に入る
+- `docker-compose run -f /home/ems/deploy/docker/docker-compose-prod.yaml certbot renew`
+  - 更新を実行する
+
+    ```log
+    Saving debug log to /var/log/letsencrypt/letsencrypt.log
+
+    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    Processing /etc/letsencrypt/renewal/www.ems-engineering.jp.conf
+    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    Cert is due for renewal, auto-renewing...
+    Plugins selected: Authenticator webroot, Installer None
+    Renewing an existing certificate
+    Performing the following challenges:
+    http-01 challenge for www.ems-engineering.jp
+    Using the webroot path /usr/share/nginx/dist for all unmatched domains.
+    Waiting for verification...
+    Cleaning up challenges
+
+    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    new certificate deployed without reload, fullchain is
+    /etc/letsencrypt/live/www.ems-engineering.jp/fullchain.pem
+    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    Congratulations, all renewals succeeded. The following certs have been renewed:
+    /etc/letsencrypt/live/www.ems-engineering.jp/fullchain.pem (success)
+    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    ```
+
+- `docker-compose -f /home/ems/deploy/docker/docker-compose-prod.yaml run certbot certificates`
+  - 更新されていることを確認する
+
+    ```log
+    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    Found the following certs:
+    Certificate Name: www.ems-engineering.jp
+    Serial Number: hogehoge
+    Domains: www.ems-engineering.jp
+    Expiry Date: 2023-11-03 23:36:10+00:00 (VALID: 89 days)
+    Certificate Path: /etc/letsencrypt/live/www.ems-engineering.jp/fullchain.pem
+    Private Key Path: /etc/letsencrypt/live/www.ems-engineering.jp/privkey.pem
+    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    ```
+
+- `docker exec -it nginx bash`
+  - nginx コンテナに入る
+- `nginx -s reload`
+  - リロードする
+
+#### 事項更新について
+- 上記手順をスクリプト化し，cron実行すれば更新できるが，確実に更新を確認するため，手動で行うことにする


### PR DESCRIPTION
## 実装内容

- サーバー証明書を更新
- 更新ログをドキュメントとして追加

## 確認手順

- `https://www.ems-engineering.jp/` にアクセスし，証明書の期限が11月になっていることを確認する

## スクリーンショット

- 証明書期限が更新されていること
<img width="322" alt="スクリーンショット 2023-08-06 9 46 52" src="https://github.com/mktkhr/stamp-iot/assets/51685340/fdeb3694-8b04-462d-8437-9f811a7ce63d">


## 確認した環境

- M1 MacBook Pro
- macOS Ventura version 13.4
- Arduino IDE version 1.8.16

resolve #99