### PR TITLE
マイコンコントローラーに不足してるエラーハンドリングを追加する

### DIFF
--- a/backend/src/main/java/com/example/stamp_app/controller/MicroControllerController.java
+++ b/backend/src/main/java/com/example/stamp_app/controller/MicroControllerController.java
@@ -85,7 +85,8 @@ public class MicroControllerController {
     @Operation(summary = "マイコン詳細取得API")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "取得成功", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MicroControllerGetResponse.class))),
-            @ApiResponse(responseCode = "400", description = "無効なアカウント", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
+            @ApiResponse(responseCode = "400", description = "不正なリクエスト内容　", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class))),
+            @ApiResponse(responseCode = "403", description = "権限のない操作", content = @Content(schema = @Schema(implementation = ObjectUtils.Null.class)))
     })
     @GetMapping(value = "/detail")
     public ResponseEntity<MicroControllerGetResponse> getMicroControllerDetail(

--- a/backend/src/main/java/com/example/stamp_app/session/RedisService.java
+++ b/backend/src/main/java/com/example/stamp_app/session/RedisService.java
@@ -47,11 +47,6 @@ public class RedisService {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
-        // 空の場合，400を返す
-        if(value == null){
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
-        }
-
         return value;
     }
 

--- a/document/API仕様/api-docs.yaml
+++ b/document/API仕様/api-docs.yaml
@@ -50,24 +50,24 @@ paths:
               $ref: '#/components/schemas/MicroControllerPostParam'
         required: true
       responses:
-        "401":
-          description: 認証エラー
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Null'
-        "400":
-          description: バリデーションエラー/無効なマイコン
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Null'
         "200":
           description: 登録成功
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/MicroControllerPostResponse'
+        "400":
+          description: バリデーションエラー/無効なマイコン
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "401":
+          description: 認証エラー
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
   /ems/measured-data:
     get:
       tags:
@@ -84,12 +84,6 @@ paths:
           type: string
         example: 61d5f7a7-7629-496e-be68-cfe022264578
       responses:
-        "403":
-          description: マイコン所有者不一致エラー
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Null'
         "200":
           description: 取得成功
           content:
@@ -98,6 +92,12 @@ paths:
                 $ref: '#/components/schemas/MeasuredDataGetResponse'
         "400":
           description: バリデーションエラー
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "403":
+          description: マイコン所有者不一致エラー
           content:
             '*/*':
               schema:
@@ -121,12 +121,6 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/Null'
-        "401":
-          description: 認証エラー
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Null'
         "400":
           description: バリデーションエラー
           content:
@@ -135,6 +129,12 @@ paths:
                 $ref: '#/components/schemas/Null'
         "403":
           description: 無効なマイコン
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "401":
+          description: 認証エラー
           content:
             '*/*':
               schema:
@@ -198,14 +198,14 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/Null'
-        "401":
-          description: 認証エラー
+        "400":
+          description: バリデーションエラー
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/Null'
-        "400":
-          description: バリデーションエラー
+        "401":
+          description: 認証エラー
           content:
             '*/*':
               schema:
@@ -226,18 +226,24 @@ paths:
           type: string
         example: 61d5f7a7-7629-496e-be68-cfe022264578
       responses:
-        "400":
-          description: 無効なアカウント
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/Null'
         "200":
           description: 取得成功
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/MicroControllerGetResponse'
+        "403":
+          description: 権限のない操作
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
+        "400":
+          description: 不正なリクエスト内容　
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Null'
     patch:
       tags:
       - MicroController
@@ -340,14 +346,14 @@ paths:
       summary: アカウント削除API
       operationId: logicalDeleteAccount
       responses:
-        "200":
-          description: 削除成功
+        "400":
+          description: バリデーションエラー
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/Null'
-        "400":
-          description: バリデーションエラー
+        "200":
+          description: 削除成功
           content:
             '*/*':
               schema:
@@ -369,8 +375,6 @@ components:
           type: string
           description: MACアドレス
       description: マイコン登録パラメータ
-    "Null":
-      type: object
     MicroControllerPostResponse:
       type: object
       properties:
@@ -412,6 +416,8 @@ components:
           description: 削除日時
           format: date-time
       description: マイコンデータ
+    "Null":
+      type: object
     EnvironmentalDataParam:
       type: object
       properties:


### PR DESCRIPTION
## 実装内容

- マイコン詳細取得APIに所有者一致の確認処理を追加
- RedisServiceでのエラーハンドリングInterceptor側に移動

## 確認手順

- ユーザーBでログインし，セッションIDを取得
- ユーザーAが所有するマイコンUUIDを指定し，ユーザーBのセッションを用いてリクエスト

## スクリーンショット

- 403が返ること. 
<img width="1602" alt="スクリーンショット 2023-08-26 19 33 17" src="https://github.com/mktkhr/stamp-iot/assets/51685340/08971809-3b83-4491-b60c-3660de4b33d2">


## 確認した環境

- M1 MacBook Pro
- macOS Ventura version 13.4
- Arduino IDE version 1.8.16

resolve #109