### PR TITLE
deploymentのreplica数の設定を削除する

### DIFF
--- a/manifest/eks/java/java-manifest.yaml
+++ b/manifest/eks/java/java-manifest.yaml
@@ -27,7 +27,6 @@ spec:
       app: java
   # javaの起動時間待ち時間を十分満たすことができるように30sを設定
   minReadySeconds: 30
-  replicas: 1
   template:
     metadata:
       labels:

--- a/manifest/eks/java/java-manifest.yaml
+++ b/manifest/eks/java/java-manifest.yaml
@@ -64,4 +64,4 @@ spec:
     targetPort: 8082
     protocol: TCP
   selector:
-    app: java
+    app: java-deployment

--- a/manifest/eks/java/java-manifest.yaml
+++ b/manifest/eks/java/java-manifest.yaml
@@ -15,7 +15,7 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 10
+        averageUtilization: 80
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifest/eks/nginx/nginx-manifest.yaml
+++ b/manifest/eks/nginx/nginx-manifest.yaml
@@ -62,4 +62,4 @@ spec:
       targetPort: 80
       protocol: TCP
   selector:
-    app: nginx-app
+    app: nginx-deployment

--- a/manifest/eks/nginx/nginx-manifest.yaml
+++ b/manifest/eks/nginx/nginx-manifest.yaml
@@ -25,7 +25,6 @@ spec:
   selector:
     matchLabels:
       app: nginx
-  replicas: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
## 実装内容

- developmentのreplicaの設定を削除
  - development側に設定値があるとhpaの設定を変更するたびに全て作り直される挙動があったため

## 確認手順

- 特になし　

## スクリーンショット

- 特になし

resolve #149 
