### PR TITLE
EKSからredisにアクセスする場合にHost名に不要な文字列が含まれることで接続できない

### DIFF
--- a/manifest/eks/java/java-manifest.yaml
+++ b/manifest/eks/java/java-manifest.yaml
@@ -40,7 +40,7 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8082
-          command: ["/bin/sh","-c","POSTGRES_DB_HOST=${POSTGRES_DB_HOST} POSTGRES_DB_PORT=${POSTGRES_DB_PORT} POSTGRES_DB_USER=${POSTGRES_DB_USER} POSTGRES_DB_PASS=${POSTGRES_DB_PASS} REDIS_HOST=${REDIS_HOST} REDIS_PORT=${REDIS_PORT} java -jar /app/server.jar --spring.profiles.active=prod"]
+          command: ["/bin/sh","-c", "java -jar /app/server.jar --spring.profiles.active=prod"]
           envFrom:
             - secretRef:
                 name: stamp-iot-secret


### PR DESCRIPTION
## 実装内容

- java-manifestのcommandを簡素に修正
  - envFromでコンテナ内にすでに環境変数が入っているため，必要なかった

## 確認手順

- 本番環境に適用時に正常に動作すること

## スクリーンショット

- 特になし

resolve #153 
