### PR TITLE
manifestにreadinesssnessProbeとlivenessProbeを追加する

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -20,6 +20,9 @@ dependencies {
     // springdoc
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
+    // actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 spring.profiles.active=${SPRING_PROFILE_ACTIVE:dev}
+
+# actuator
+management.server.port=7082
+management.endpoint.health.probes.enabled=true
+management.endpoints.web.exposure.include=health,info,prometheus,metrics

--- a/manifest/eks/java/java-manifest.yaml
+++ b/manifest/eks/java/java-manifest.yaml
@@ -25,8 +25,6 @@ spec:
   selector:
     matchLabels:
       app: java-app
-  # javaの起動時間待ち時間を十分満たすことができるように30sを設定
-  minReadySeconds: 30
   template:
     metadata:
       labels:
@@ -50,6 +48,26 @@ spec:
               cpu: 500m
             limits:
               cpu: 1000m
+          livenessProbe:
+            # jarの起動時間と近しい値を設定する
+            initialDelaySeconds: 20
+            httpGet:
+              port: 7082
+              path: /actuator/health/liveness
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 2
+          readinessProbe:
+            # jarの起動時間と近しい値を設定する
+            initialDelaySeconds: 20
+            httpGet:
+              port: 7082
+              path: /actuator/health/readiness
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 2
 ---
 apiVersion: v1
 kind: Service

--- a/manifest/eks/nginx/nginx-manifest.yaml
+++ b/manifest/eks/nginx/nginx-manifest.yaml
@@ -47,6 +47,24 @@ spec:
               cpu: 300m
             limits:
               cpu: 500m
+          livenessProbe:
+            initialDelaySeconds: 5
+            httpGet:
+              port: 80
+              path: /
+              scheme: HTTP
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 2
+          readinessProbe:
+            initialDelaySeconds: 5
+            exec:
+              command: ["ls", "/usr/share/nginx/dist/index.html"]
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 2
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## 実装内容

- javaにactuatorの依存関係を追加
  - 後にprometheusとも連携させたいのでそれらも有効化
- java，nginxのmanifestにprobeを追加

## 確認手順

- ユーザーとして正常にログインできること

## スクリーンショット

- liveness

<img width="376" alt="スクリーンショット 2024-07-06 8 42 15" src="https://github.com/mktkhr/stamp-iot/assets/51685340/d86a0814-fb85-4011-8b61-f6948b84bc4f">

- readiness

<img width="383" alt="スクリーンショット 2024-07-06 8 42 02" src="https://github.com/mktkhr/stamp-iot/assets/51685340/e2b58246-84fc-4f19-b84b-518095cb7ec1">

- javaのpodでの動作確認

https://github.com/mktkhr/stamp-iot/issues/155#issuecomment-2211542896

- nginxのpodでの動作確認

https://github.com/mktkhr/stamp-iot/issues/155#issuecomment-2211548005

- probe付きでのログインの動作確認

https://github.com/mktkhr/stamp-iot/issues/155#issuecomment-2211549059


resolve #155 
