### PR TITLE
dev用のビルドjobを追加する

### DIFF
--- a/.github/workflows/frontend.build-test.yaml
+++ b/.github/workflows/frontend.build-test.yaml
@@ -79,8 +79,29 @@ jobs:
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Docker meta
-        id: meta
+      - name: Docker meta(DEV)
+        id: meta-dev
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/mktkhr/stamp-iot/nginx-dev
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=,suffix=,format=short
+
+      - name: Build and push(DEV)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: ${{ steps.meta-dev.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Docker meta(PROD)
+        id: meta-prod
         uses: docker/metadata-action@v5
         with:
           images: |
@@ -89,13 +110,13 @@ jobs:
             type=raw,value=latest
             type=sha,prefix=,suffix=,format=short
 
-      - name: Build and push
+      - name: Build and push(PROD)
         uses: docker/build-push-action@v6
         with:
           context: ./frontend
-          file: ./frontend/Dockerfile
+          file: ./frontend/Dockerfile-eks
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta-prod.outputs.tags }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -54,13 +54,10 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
-        <appender-ref ref="FILE"/>
-    </root>
-
     <!-- dev では INFO 以上を出力 -->
     <springProfile name="dev">
         <root level="INFO">
+            <appender-ref ref="FILE"/>
             <appender-ref ref="STDOUT"/>
             <appender-ref ref="STDERR"/>
         </root>

--- a/docker/dev/docker-frontend-compose.yaml
+++ b/docker/dev/docker-frontend-compose.yaml
@@ -2,7 +2,7 @@ name: ems
 
 services:
   nginx:
-    image: ghcr.io/mktkhr/stamp-iot/nginx:latest
+    image: ghcr.io/mktkhr/stamp-iot/nginx-dev:latest
     container_name: nginx
     tty: true
     restart: always

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,13 +1,8 @@
+# 開発環境用
 FROM --platform=$BUILDPLATFORM nginx:1.27.0
 
-COPY ./nginx-eks.conf /etc/nginx/nginx.conf
+COPY ./nginx.conf /etc/nginx/nginx.conf
 COPY ./dist /usr/share/nginx/dist
 
-RUN chown -R nginx /var/cache/nginx \
-  && chmod -R g+w /var/cache/nginx
-
-# uid=100(nginx) gid=101(nginx) groups=101(nginx)
-USER nginx
-
-EXPOSE 8080
+EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile-eks
+++ b/frontend/Dockerfile-eks
@@ -1,0 +1,14 @@
+# 本番環境(EKS)用
+FROM --platform=$BUILDPLATFORM nginx:1.27.0
+
+COPY ./nginx-eks.conf /etc/nginx/nginx.conf
+COPY ./dist /usr/share/nginx/dist
+
+RUN chown -R nginx /var/cache/nginx \
+  && chmod -R g+w /var/cache/nginx
+
+# uid=100(nginx) gid=101(nginx) groups=101(nginx)
+USER nginx
+
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -40,6 +40,7 @@ http {
         server_name www.ems-engineering.jp;
 
         location ^~ /.well-known/acme-challenge/ {
+            try_files $uri /index.html;
             root /usr/share/nginx/dist;
             index index.html;
         }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -39,7 +39,7 @@ http {
         listen 80;
         server_name www.ems-engineering.jp;
 
-        location /.well-known/acme-challenge/ {
+        location ^~ /.well-known/acme-challenge/ {
             root /usr/share/nginx/dist;
             index index.html;
         }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,6 +1,6 @@
-user nginx;
 worker_processes auto;
-error_log /var/log/nginx/error.log debug;
+## 標準出力に設定
+error_log /dev/stderr debug;
 pid /var/run/nginx.pid;
 
 events {
@@ -27,7 +27,8 @@ http {
                                 '"request_time":"$request_time",'
                                 '"response_time":"$upstream_response_time"}';
 
-    access_log /var/log/nginx/access.log json;
+    ## 標準出力に設定
+    access_log /dev/stdout json;
 
     ##dos対策
     limit_req_zone $binary_remote_addr zone=limit:10m rate=10r/s;


### PR DESCRIPTION
## 実装内容

- devとprod用のフロントエンドビルドjobを追加

## 確認手順

- devとprod用のimageが作成され，dev用のコンテナで開発環境が起動できていることを確認

## スクリーンショット

- 開発環境

![スクリーンショット 2024-09-08 19 05 06](https://github.com/user-attachments/assets/35308ef3-0f90-471c-94eb-85518858fafa)


resolve #169 
