### PR TITLE
開発環境にJVMのメトリクス監視を追加する

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
 management:
   server:
     port: 7082
-  endpoint:
+  endpoints:
     health:
       probes:
         enabled: true

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -62,6 +62,7 @@ services:
     container_name: java
     tty: true
     ports:
+      - 7082:7082
       - 8082:8082
       - 5005:5005
     depends_on:


### PR DESCRIPTION
## 実装内容

- prometheusのエンドポイントを公開する設定値の誤りを修正

## 確認手順

- ブラウザで `localhost:7082/actuator/prometheus` にアクセスしてメトリクスを取得できることを確認する

## スクリーンショット

- 特になし
