### PR TITLE
開発環境にJVMのメトリクス監視を追加する

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     // actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.13.4'
 
     compileOnly 'org.projectlombok:lombok:1.18.34'
     annotationProcessor 'org.projectlombok:lombok:1.18.34'

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -38,3 +38,19 @@ springdoc:
     enabled: false
   swagger-ui:
     enabled: false
+
+# actuator
+management:
+  server:
+    port: 7082
+  endpoints:
+    health:
+      probes:
+        enabled: true
+    web:
+      exposure:
+        include:
+          - health
+          - info
+          - prometheus
+          - metrics


### PR DESCRIPTION
## 実装内容

- JVMのメトリクスが取得できるように修正

## 確認手順

- grafanaにアクセスしてダッシュボードを確認する

## スクリーンショット

- JVMのメトリクスが確認できていること

<img width="1680" alt="スクリーンショット 2024-10-03 23 27 34" src="https://github.com/user-attachments/assets/432b707f-cc11-47df-bd24-e88082a06162">

resolve #180
