### PR TITLE
開発環境にLokiを導入し，Javaのログを回収する

### DIFF
--- a/docker/dev/docker-backend-compose.yaml
+++ b/docker/dev/docker-backend-compose.yaml
@@ -17,8 +17,14 @@ services:
     command: /bin/bash -c "APP_DOMAIN=${APP_DOMAIN} POSTGRES_DB_HOST=${POSTGRES_DB_HOST} POSTGRES_DB_PORT=${POSTGRES_DB_PORT} POSTGRES_DB_USER=${POSTGRES_DB_USER} POSTGRES_DB_PASS=${POSTGRES_DB_PASS} REDIS_HOST=${REDIS_HOST} REDIS_PORT=${REDIS_PORT} java -jar /app/server.jar --spring.profiles.active=prod"
     ports:
       - 8082:8082
+    expose:
+      - 7082
     networks:
       - ems-network
+    logging:
+      driver: loki
+      options:
+        loki-url: http://127.0.0.1:3100/loki/api/v1/push
 
 networks:
   ems-network:

--- a/docker/dev/docker-observer-compose.yaml
+++ b/docker/dev/docker-observer-compose.yaml
@@ -13,6 +13,10 @@ services:
         source: prometheus-data
         target: /prometheus
     command: "--config.file=/etc/prometheus/prometheus.yaml"
+    ports:
+      - 9090:9090
+    networks:
+      - ems-network
 
   node-exporter:
     image: prom/node-exporter:latest
@@ -20,6 +24,8 @@ services:
     restart: always
     ports:
       - 8091:9100
+    networks:
+      - ems-network
 
   grafana:
     image: grafana/grafana
@@ -39,6 +45,8 @@ services:
       - ./grafana/config/config.env
     ports:
       - 8092:8092
+    networks:
+      - ems-network
 
   loki:
     image: grafana/loki:3.2.0

--- a/docker/dev/docker-observer-compose.yaml
+++ b/docker/dev/docker-observer-compose.yaml
@@ -40,6 +40,17 @@ services:
     ports:
       - 8092:8092
 
+  loki:
+    image: grafana/loki:3.2.0
+    container_name: ems-loki
+    ports:
+      - 3100:3100
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - loki-data:/data/loki
+    networks:
+      - ems-network
+
 networks:
   ems-network:
     name: ems-network
@@ -49,3 +60,4 @@ networks:
 volumes:
   prometheus-data:
   grafana-data:
+  loki-data:


### PR DESCRIPTION
## 実装内容

- 開発環境のJavaのコンテナログをlokiに流すように修正

## 確認手順

- grafanaにてlokiのログを確認する

## スクリーンショット

- grafanaでログが表示されていること

<img width="1680" alt="スクリーンショット 2024-10-16 23 22 59" src="https://github.com/user-attachments/assets/b01ffba5-85c3-440e-b5e3-b4d71022eeaa">

resolve #184 
