### PR TITLE
開発環境のNginxのログをLokiに流すように変更する

### DIFF
--- a/docker/dev/docker-frontend-compose.yaml
+++ b/docker/dev/docker-frontend-compose.yaml
@@ -15,6 +15,10 @@ services:
       - 443:443
     networks:
       - ems-network
+    logging:
+      driver: loki
+      options:
+        loki-url: http://127.0.0.1:3100/loki/api/v1/push
 
 networks:
   ems-network:


### PR DESCRIPTION
## 実装内容

- 開発環境のNginxのログをLokiに転送するように修正

## 確認手順

- Grafanaにアクセスしてログを確認する

## スクリーンショット

- Jsonバージョン

<img width="1680" alt="スクリーンショット 2024-10-20 13 16 16" src="https://github.com/user-attachments/assets/9bc2a540-4ff3-4801-8db0-6a433ec8a778">

-  行バージョン

<img width="1680" alt="スクリーンショット 2024-10-20 13 15 40" src="https://github.com/user-attachments/assets/2cc7e7d8-ec4a-4c9d-8fd2-85b240603f4c">


resolve #189 
