### PR TITLE
ビジュアルリグレッションテストのCIを追加する

### DIFF
--- a/.github/workflows/composite/frontend-cache-screenshot/action.yaml
+++ b/.github/workflows/composite/frontend-cache-screenshot/action.yaml
@@ -1,0 +1,19 @@
+name: "Cache Expected Screenshots"
+description: "スクリーンショットのキャッシュの有無を評価する"
+outputs:
+  cache-hit:
+    description: "スクリーンショットのキャッシュが存在するか?"
+    value: ${{ steps.expected_screenshots_cache_id.outputs.cache-hit }}
+runs:
+  using: "composite"
+  steps:
+    - name: Get commit hash of current branch
+      id: get_hash
+      run: echo "hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Cache screenshots
+      uses: actions/cache@v4
+      id: expected_screenshots_cache_id
+      with:
+        path: __screenshots__
+        key: ${{ runner.os }}-screenshots-${{ steps.get_hash.outputs.hash }}

--- a/.github/workflows/composite/frontend-cache-storybook-static/action.yaml
+++ b/.github/workflows/composite/frontend-cache-storybook-static/action.yaml
@@ -1,0 +1,24 @@
+name: "Restore/Build Storybook"
+description: "キャッシュに保存されているStorybookのビルド成果物を再利用する"
+runs:
+  using: "composite"
+  steps:
+    - name: Get commit hash of current branch
+      id: get_hash
+      run: echo "hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    # キャッシュされたStorybookのビルド成果物を取得する
+    - name: Restore cached storybook build result
+      id: storybook_cache
+      uses: actions/cache@v4
+      with:
+        path: storybook-static
+        key: ${{ runner.os }}-storybook-static-${{ steps.get_hash.outputs.hash  }}
+
+    # キャッシュが存在しなかったら、Storybookをビルドする
+    - name: Build Storybook
+      if: ${{ steps.storybook_cache.outputs.cache-hit != 'true'}}
+      run: yarn build-storybook
+      working-directory: ./frontend
+      shell: bash

--- a/.github/workflows/composite/frontend-setup/action.yaml
+++ b/.github/workflows/composite/frontend-setup/action.yaml
@@ -1,0 +1,34 @@
+name: "Package Install"
+description: "Frontendのパッケージインストールを行うAction"
+
+runs:
+  using: "composite"
+
+  strategy:
+    matrix:
+      node-version: [20.15.1]
+
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: "yarn"
+        cache-dependency-path: yarn-lock.json
+      working-directory: ./frontend
+    # キャッシュが存在するかを確認する
+    - name: Restore node_modules From Cache
+      id: node_modules_cache
+      uses: actions/cache@v4
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn-lock.json') }}
+      working-directory: ./frontend
+    # キャッシュが存在しなかった場合はInstall
+    - name: Install Dependencies
+      if: ${{ steps.node_modules_cache.outputs.cache-hit != 'true'}}
+      run: |
+        npm install -g yarn
+        yarn
+      shell: bash
+      working-directory: ./frontend

--- a/.github/workflows/frontend.build-test.yaml
+++ b/.github/workflows/frontend.build-test.yaml
@@ -121,6 +121,49 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  screenshot-main:
+    name: Take Expected Screenshots At Main Branch
+    runs-on: [self-hosted]
+    timeout-minutes: 30
+    needs: build
+
+    strategy:
+      matrix:
+        node-version: [20.15.1]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      # スクリーンショットのキャッシュの有無を評価する
+      - name: Restore cached expected screenshots
+        id: expected_screenshots_cache
+        uses: ./.github/composite/frontend-cache-scr
+
+      # 以下はキャッシュが存在しなかった場合に実行される
+      - name: Use Node.js ${{ matrix.node-version }}
+        if: ${{ steps.expected_screenshots_cache.outputs.cache-hit != 'true'}}
+        uses: ./.github/composite/frontend-setup
+
+      - name: Restore or build storybook # キャッシュにスクショが保存されてなかったらStorybookをビルドしてスクショ撮影する
+        if: ${{ steps.expected_screenshots_cache.outputs.cache-hit != 'true'}}
+        uses: ./.github/composite_actions/cache-storybook-static
+
+      - name: Take expected screenshots
+        if: ${{ steps.expected_screenshots_cache.outputs.cache-hit != 'true'}}
+        run: yarn storycap:ci
+        working-directory: ./frontend
+
+      - name: Upload expected screenshots to artifact
+        uses: actions/upload-artifact@v4
+
+        with:
+          name: expected-screenshots
+          path: __screenshots__
+          retention-days: 30
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/frontend.build-test.yaml
+++ b/.github/workflows/frontend.build-test.yaml
@@ -140,7 +140,7 @@ jobs:
       # スクリーンショットのキャッシュの有無を評価する
       - name: Restore cached expected screenshots
         id: expected_screenshots_cache
-        uses: ./.github/composite/frontend-cache-scr
+        uses: ./.github/composite/frontend-cache-screenshot
 
       # 以下はキャッシュが存在しなかった場合に実行される
       - name: Use Node.js ${{ matrix.node-version }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Restore or build storybook # キャッシュにスクショが保存されてなかったらStorybookをビルドしてスクショ撮影する
         if: ${{ steps.expected_screenshots_cache.outputs.cache-hit != 'true'}}
-        uses: ./.github/composite_actions/cache-storybook-static
+        uses: ./.github/composite/cache-storybook-static
 
       - name: Take expected screenshots
         if: ${{ steps.expected_screenshots_cache.outputs.cache-hit != 'true'}}

--- a/.github/workflows/frontend.build-test.yaml
+++ b/.github/workflows/frontend.build-test.yaml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Restore or build storybook # キャッシュにスクショが保存されてなかったらStorybookをビルドしてスクショ撮影する
         if: ${{ steps.expected_screenshots_cache.outputs.cache-hit != 'true'}}
-        uses: ./.github/workflows/composite/cache-storybook-static
+        uses: ./.github/workflows/composite/frontend-cache-storybook-static
 
       - name: Take expected screenshots
         if: ${{ steps.expected_screenshots_cache.outputs.cache-hit != 'true'}}

--- a/.github/workflows/frontend.build-test.yaml
+++ b/.github/workflows/frontend.build-test.yaml
@@ -140,16 +140,16 @@ jobs:
       # スクリーンショットのキャッシュの有無を評価する
       - name: Restore cached expected screenshots
         id: expected_screenshots_cache
-        uses: ./.github/composite/frontend-cache-screenshot
+        uses: ./.github/workflows/composite/frontend-cache-screenshot
 
       # 以下はキャッシュが存在しなかった場合に実行される
       - name: Use Node.js ${{ matrix.node-version }}
         if: ${{ steps.expected_screenshots_cache.outputs.cache-hit != 'true'}}
-        uses: ./.github/composite/frontend-setup
+        uses: ./.github/workflows/composite/frontend-setup
 
       - name: Restore or build storybook # キャッシュにスクショが保存されてなかったらStorybookをビルドしてスクショ撮影する
         if: ${{ steps.expected_screenshots_cache.outputs.cache-hit != 'true'}}
-        uses: ./.github/composite/cache-storybook-static
+        uses: ./.github/workflows/composite/cache-storybook-static
 
       - name: Take expected screenshots
         if: ${{ steps.expected_screenshots_cache.outputs.cache-hit != 'true'}}

--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -38,10 +38,9 @@ const preview: Preview = {
       template:
         '<div id="app" style="position: absolute; inset: 0; margin: auto; padding: 16px;"><story/></div>',
     }),
+    withScreenshot(options),
   ],
   loaders: [mswLoader],
 };
-
-export const decorators = [withScreenshot(options)];
 
 export default preview;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "storybook build",
     "storycap:before": "storycap -o ./__screenshots__/before --serverCmd \"yarn storybook\" http://localhost:6006",
     "storycap:after": "storycap -o ./__screenshots__/after --serverCmd \"yarn storybook\" http://localhost:6006",
+    "storycap:ci": "storycap -o ./__screenshots__ --serverCmd \"yarn storybook\" http://localhost:6006",
     "vrt": "reg-cli ./__screenshots__/after ./__screenshots__/before ./__screenshots__/diff -R ./__screenshots__/report.html -I true"
   },
   "dependencies": {


### PR DESCRIPTION
## 実装内容

- CIのベースを追加
  - ただし，mainブランチに対象のacitonが存在しないためjobに失敗する

## 確認手順

- 特になし

## スクリーンショット

- 特になし