### PR TITLE
MeasuredDataServiceにDBを使ったテストを追加する

### DIFF
--- a/backend/src/test/java/com/example/stamp_app/service/measured_data/MeasuredDataServiceTest.kt
+++ b/backend/src/test/java/com/example/stamp_app/service/measured_data/MeasuredDataServiceTest.kt
@@ -1,0 +1,100 @@
+package com.example.stamp_app.service.measured_data
+
+import com.example.stamp_app.controller.param.EnvironmentalDataParam
+import com.example.stamp_app.controller.param.MeasuredDataPostParam
+import com.example.stamp_app.controller.param.Sdi12Param
+import com.example.stamp_app.controller.response.measuredDataGetResponse.EnvironmentalDataGetResponse
+import com.example.stamp_app.controller.response.measuredDataGetResponse.Sdi12DataAndDoy
+import com.example.stamp_app.controller.response.measuredDataGetResponse.Sdi12DataGetResponse
+import com.example.stamp_app.controller.response.measuredDataGetResponse.VoltageDataGetResponse
+import com.example.stamp_app.domain.exception.EMSResourceNotFoundException
+import com.example.stamp_app.service.MeasuredDataService
+import com.example.stamp_app.service.TestBase
+import org.junit.jupiter.api.*
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Transactional
+class MeasuredDataServiceTest : TestBase() {
+	@Autowired
+	private lateinit var measuredDataService: MeasuredDataService
+
+	@Nested
+	inner class AddMeasuredDataTest {
+
+		private val sdi12Param = Sdi12Param(
+			1L,
+			"1",
+			"12.34",
+			"1.23",
+			"2.34",
+			"3.45",
+			"4.56",
+			"1.234",
+			"2.345",
+			"3.456"
+		)
+
+		private val environmentalParam = EnvironmentalDataParam(
+			"1234.56",
+			"12.34",
+			"23.45",
+			"3456",
+			"4567",
+			"567"
+		)
+
+		@Test
+		@DisplayName("存在しないMicroControllerに対する登録の場合，EMSResourceNotFoundExceptionが発生すること")
+		fun `case1-1`() {
+			loadDatasetAndInsert("src/test/resources/service/measured_data/case1.xml")
+
+			val noMicroControllerParam = MeasuredDataPostParam(
+				"CC:CC:CC:CC:CC:CC",
+				listOf(sdi12Param),
+				listOf(environmentalParam),
+				"1"
+			)
+
+			assertThrows<EMSResourceNotFoundException> { measuredDataService.addMeasuredData(noMicroControllerParam) }
+		}
+
+		@Test
+		@DisplayName("アカウントに紐づかないMicroControllerに対する登録の場合，EMSResourceNotFoundExceptionが発生すること")
+		fun `case1-2`() {
+			loadDatasetAndInsert("src/test/resources/service/measured_data/case1.xml")
+
+			val noAccountRelationMicroControllerParam = MeasuredDataPostParam(
+				"BB:BB:BB:BB:BB:BB",
+				listOf(sdi12Param),
+				listOf(environmentalParam),
+				"1"
+			)
+
+			assertThrows<EMSResourceNotFoundException> {
+				measuredDataService.addMeasuredData(
+					noAccountRelationMicroControllerParam
+				)
+			}
+		}
+
+		@Test
+		@DisplayName("存在するMicroControllerに対する登録の場合，正常に登録できること")
+		fun `case1-3`() {
+			loadDatasetAndInsert("src/test/resources/service/measured_data/case1.xml")
+
+			val param = MeasuredDataPostParam(
+				"AA:AA:AA:AA:AA:AA",
+				listOf(sdi12Param),
+				listOf(environmentalParam),
+				"1"
+			)
+
+			assertDoesNotThrow {
+				measuredDataService.addMeasuredData(param)
+			}
+		}
+
+	}
+}

--- a/backend/src/test/java/com/example/stamp_app/service/measured_data/MeasuredDataServiceTest.kt
+++ b/backend/src/test/java/com/example/stamp_app/service/measured_data/MeasuredDataServiceTest.kt
@@ -97,4 +97,227 @@ class MeasuredDataServiceTest : TestBase() {
 		}
 
 	}
+
+	@Nested
+	inner class GetMeasuredDataTest {
+
+		private val sdi12Param = Sdi12Param(
+			1L,
+			"1",
+			"12.34",
+			"1.23",
+			"2.34",
+			"3.45",
+			"4.56",
+			"1.234",
+			"2.345",
+			"3.456"
+		)
+
+		private val environmentalParam = EnvironmentalDataParam(
+			"1234.56",
+			"12.34",
+			"23.45",
+			"3456",
+			"4567",
+			"567"
+		)
+
+		@Test
+		@DisplayName("存在しないMicroControllerに対する取得の場合，EMSResourceNotFoundExceptionが発生すること")
+		fun `case2-1`() {
+			loadDatasetAndInsert("src/test/resources/service/measured_data/case2.xml")
+
+			assertThrows<EMSResourceNotFoundException> {
+				measuredDataService.getMeasuredData(
+					"8ea20e98-043d-4117-8a24-771351bce045",
+					"99999999-043d-4117-8a24-771351bce045"
+				)
+			}
+		}
+
+		@Test
+		@DisplayName("存在しないユーザーのリクエストの場合，EMSResourceNotFoundExceptionが発生すること")
+		fun `case2-2`() {
+			loadDatasetAndInsert("src/test/resources/service/measured_data/case2.xml")
+
+			assertThrows<EMSResourceNotFoundException> {
+				measuredDataService.getMeasuredData(
+					"99999999-043d-4117-8a24-771351bce045",
+					"1ea20e98-043d-4117-8a24-771351bce045"
+				)
+			}
+		}
+
+		@Test
+		@DisplayName("MicroControllerの所有者とリクエストユーザーが異なる場合，EMSResourceNotFoundExceptionが発生すること")
+		fun `case2-3`() {
+			loadDatasetAndInsert("src/test/resources/service/measured_data/case2.xml")
+
+			assertThrows<EMSResourceNotFoundException> {
+				measuredDataService.getMeasuredData(
+					"8ea20e98-043d-4117-8a24-771351bce046",
+					"1ea20e98-043d-4117-8a24-771351bce045"
+				)
+			}
+		}
+
+		@Test
+		@DisplayName("1つのMeasuredMasterに2つのSDI12アドレスのセンサが紐づいている場合，すべて取得できること")
+		fun `case2-4`() {
+			loadDatasetAndInsert("src/test/resources/service/measured_data/case2.xml")
+
+			val measuredDataGetResponse = measuredDataService.getMeasuredData(
+				"8ea20e98-043d-4117-8a24-771351bce045",
+				"1ea20e98-043d-4117-8a24-771351bce045"
+			)
+
+			Assertions.assertEquals(2, measuredDataGetResponse.sdi12Data.size)
+			Assertions.assertEquals(2, measuredDataGetResponse.environmentalData.size)
+			Assertions.assertEquals(2, measuredDataGetResponse.voltageData.size)
+
+			// アドレス1と2を両方取得できること
+			Assertions.assertEquals(
+				listOf("1", "2"),
+				measuredDataGetResponse.sdi12Data.map { item -> item.sdiAddress }.distinct()
+			)
+
+			val sdi12ResponseList = listOf(
+				Sdi12DataGetResponse(
+					"1",
+					mutableListOf(
+						Sdi12DataAndDoy(
+							1L,
+							"1",
+							"34.56",
+							"12.34",
+							"1.234",
+							"5.67",
+							"23.45",
+							"2.345",
+							"3.456",
+							"4.567",
+							LocalDateTime.parse("2025-01-01T01:00:00.000"),
+							LocalDateTime.parse("2025-01-01T01:00:00.000"),
+							null,
+						),
+						Sdi12DataAndDoy(
+							2L,
+							"1.1",
+							"45.67",
+							"23.45",
+							"2.345",
+							"6.789",
+							"34.56",
+							"3.456",
+							"4.567",
+							"5.678",
+							LocalDateTime.parse("2025-01-01T02:00:00.000"),
+							LocalDateTime.parse("2025-01-01T02:00:00.000"),
+							null,
+						)
+					)
+				),
+				Sdi12DataGetResponse(
+					"2",
+					mutableListOf(
+						Sdi12DataAndDoy(
+							1L,
+							"1",
+							"34.56",
+							"12.34",
+							"1.234",
+							"5.67",
+							"23.45",
+							"2.345",
+							"3.456",
+							"4.567",
+							LocalDateTime.parse("2025-01-01T01:00:00.000"),
+							LocalDateTime.parse("2025-01-01T01:00:00.000"),
+							null,
+						),
+						Sdi12DataAndDoy(
+							2L,
+							"1.1",
+							"45.67",
+							"23.45",
+							"2.345",
+							"6.789",
+							"34.56",
+							"3.456",
+							"4.567",
+							"5.678",
+							LocalDateTime.parse("2025-01-01T02:00:00.000"),
+							LocalDateTime.parse("2025-01-01T02:00:00.000"),
+							null,
+						)
+					)
+				)
+			)
+
+			Assertions.assertEquals(
+				sdi12ResponseList,
+				measuredDataGetResponse.sdi12Data
+			)
+
+			val environmentalResponseList = listOf(
+				EnvironmentalDataGetResponse(
+					1L,
+					"1",
+					"1234.56",
+					"23.45",
+					"12.34",
+					"1234",
+					"345",
+					"123",
+					LocalDateTime.parse("2025-01-01T01:00:00.000"),
+					LocalDateTime.parse("2025-01-01T01:00:00.000"),
+					null
+				),
+				EnvironmentalDataGetResponse(
+					2L,
+					"1.1",
+					"2345.67",
+					"34.56",
+					"23.45",
+					"2345",
+					"456",
+					"234",
+					LocalDateTime.parse("2025-01-01T02:00:00.000"),
+					LocalDateTime.parse("2025-01-01T02:00:00.000"),
+					null
+				)
+			)
+
+			Assertions.assertEquals(
+				environmentalResponseList,
+				measuredDataGetResponse.environmentalData
+			)
+
+			val voltageDataGetResponse = mutableListOf(
+				VoltageDataGetResponse(
+					1L,
+					"1",
+					"12.34",
+					LocalDateTime.parse("2025-01-01T01:00:00.000"),
+					LocalDateTime.parse("2025-01-01T01:00:00.000"),
+					null
+				),
+				VoltageDataGetResponse(
+					2L,
+					"1.1",
+					"23.45",
+					LocalDateTime.parse("2025-01-01T02:00:00.000"),
+					LocalDateTime.parse("2025-01-01T02:00:00.000"),
+					null
+				)
+			)
+
+			Assertions.assertEquals(
+				voltageDataGetResponse,
+				measuredDataGetResponse.voltageData
+			)
+		}
+
+	}
 }

--- a/backend/src/test/resources/service/measured_data/case1.xml
+++ b/backend/src/test/resources/service/measured_data/case1.xml
@@ -1,0 +1,40 @@
+<dataset>
+    <account
+            id="1"
+            uuid="8ea20e98-043d-4117-8a24-771351bce045"
+            mail_address="test@example.com"
+            name="TestAccount"
+            password="0c74c6051287c95df4cf530675cacced"
+            created_at="2025-01-01 01:00:00.000"
+            updated_at="2025-01-01 01:00:00.000"
+            deleted_at="[null]"
+    />
+
+    <micro_controller
+            id="1"
+            uuid="1ea20e98-043d-4117-8a24-771351bce045"
+            interval="60"
+            mac_address="AA:AA:AA:AA:AA:AA"
+            name="テスト端末"
+            sdi12address="1"
+            created_at="2025-01-01 01:00:00.000"
+            updated_at="2025-01-01 01:00:00.000"
+            deleted_at="[null]"
+            account_id="1"
+    />
+
+    <!--アカウント紐付きなし-->
+    <micro_controller
+            id="2"
+            uuid="2ea20e98-043d-4117-8a24-771351bce045"
+            interval="60"
+            mac_address="BB:BB:BB:BB:BB:BB"
+            name="テスト端末B"
+            sdi12address="1,2,3"
+            created_at="2025-01-01 01:00:00.000"
+            updated_at="2025-01-01 01:00:00.000"
+            deleted_at="[null]"
+            account_id="[null]"
+    />
+
+</dataset>

--- a/backend/src/test/resources/service/measured_data/case2.xml
+++ b/backend/src/test/resources/service/measured_data/case2.xml
@@ -1,0 +1,153 @@
+<dataset>
+    <account
+            id="1"
+            uuid="8ea20e98-043d-4117-8a24-771351bce045"
+            mail_address="test@example.com"
+            name="TestAccount"
+            password="0c74c6051287c95df4cf530675cacced"
+            created_at="2025-01-01 01:00:00.000"
+            updated_at="2025-01-01 01:00:00.000"
+            deleted_at="[null]"
+    />
+
+    <account
+            id="2"
+            uuid="8ea20e98-043d-4117-8a24-771351bce046"
+            mail_address="test2@example.com"
+            name="TestAccount2"
+            password="0c74c6051287c95df4cf530675cacced"
+            created_at="2025-01-01 01:00:00.000"
+            updated_at="2025-01-01 01:00:00.000"
+            deleted_at="[null]"
+    />
+
+    <micro_controller
+            id="1"
+            uuid="1ea20e98-043d-4117-8a24-771351bce045"
+            interval="60"
+            mac_address="AA:AA:AA:AA:AA:AA"
+            name="テスト端末"
+            sdi12address="1"
+            created_at="2025-01-01 01:00:00.000"
+            updated_at="2025-01-01 01:00:00.000"
+            deleted_at="[null]"
+            account_id="1"
+    />
+
+    <!--アカウント紐付きなし-->
+    <micro_controller
+            id="2"
+            uuid="2ea20e98-043d-4117-8a24-771351bce045"
+            interval="60"
+            mac_address="BB:BB:BB:BB:BB:BB"
+            name="テスト端末B"
+            sdi12address="1,2,3"
+            created_at="2025-01-01 01:00:00.000"
+            updated_at="2025-01-01 01:00:00.000"
+            deleted_at="[null]"
+            account_id="[null]"
+    />
+
+    <measured_data_master
+            id="1"
+            voltage="12.34"
+            day_of_year="1"
+            created_at="2025-01-01 01:00:00.000"
+            updated_at="2025-01-01 01:00:00.000"
+            deleted_at="[null]"
+            micro_controller_id="1"
+    />
+
+    <measured_data_master
+            id="2"
+            voltage="23.45"
+            day_of_year="1.1"
+            created_at="2025-01-01 02:00:00.000"
+            updated_at="2025-01-01 02:00:00.000"
+            deleted_at="[null]"
+            micro_controller_id="1"
+    />
+
+    <sdi12data
+            id="1"
+            bulk_relative_permittivity="1.234"
+            gravitational_accelerationxaxis="2.345"
+            gravitational_accelerationyaxis="3.456"
+            gravitational_accelerationzaxis="4.567"
+            soil_bulk_electric_conductivity="5.67"
+            sdi_address="1"
+            soil_temperature="12.34"
+            soil_pore_water_electric_conductivity="23.45"
+            volumetric_water_content="34.56"
+            measured_data_master_id="1"
+            sensor_id="1"
+    />
+
+    <sdi12data
+            id="2"
+            bulk_relative_permittivity="1.234"
+            gravitational_accelerationxaxis="2.345"
+            gravitational_accelerationyaxis="3.456"
+            gravitational_accelerationzaxis="4.567"
+            soil_bulk_electric_conductivity="5.67"
+            sdi_address="2"
+            soil_temperature="12.34"
+            soil_pore_water_electric_conductivity="23.45"
+            volumetric_water_content="34.56"
+            measured_data_master_id="1"
+            sensor_id="1"
+    />
+
+    <sdi12data
+            id="3"
+            bulk_relative_permittivity="2.345"
+            gravitational_accelerationxaxis="3.456"
+            gravitational_accelerationyaxis="4.567"
+            gravitational_accelerationzaxis="5.678"
+            soil_bulk_electric_conductivity="6.789"
+            sdi_address="1"
+            soil_temperature="23.45"
+            soil_pore_water_electric_conductivity="34.56"
+            volumetric_water_content="45.67"
+            measured_data_master_id="2"
+            sensor_id="1"
+    />
+
+    <sdi12data
+            id="4"
+            bulk_relative_permittivity="2.345"
+            gravitational_accelerationxaxis="3.456"
+            gravitational_accelerationyaxis="4.567"
+            gravitational_accelerationzaxis="5.678"
+            soil_bulk_electric_conductivity="6.789"
+            sdi_address="2"
+            soil_temperature="23.45"
+            soil_pore_water_electric_conductivity="34.56"
+            volumetric_water_content="45.67"
+            measured_data_master_id="2"
+            sensor_id="1"
+    />
+
+    <environmental_data
+            id="1"
+            atmospheric_pressure="1234.56"
+            analog_value="123"
+            co2concentration="1234"
+            relative_humidity="12.34"
+            temperature="23.45"
+            total_volatile_organic_compounds="345"
+            measured_data_master_id="1"
+    />
+
+    <environmental_data
+            id="2"
+            atmospheric_pressure="2345.67"
+            analog_value="234"
+            co2concentration="2345"
+            relative_humidity="23.45"
+            temperature="34.56"
+            total_volatile_organic_compounds="456"
+            measured_data_master_id="2"
+    />
+
+</dataset>


### PR DESCRIPTION
## 実装内容

- MeasuredDataServiceにDBを使ったテストを追加する

## 確認手順

- テストを実行する

## スクリーンショット

- 特になし

resolve #207 
